### PR TITLE
docs: Add magic system documentation framework (Phase 00)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -601,10 +601,39 @@ EventBus.turn_advanced.connect(func(turn): print("Turn advanced: ", turn))
 
 ---
 
+## Magic System (Planned)
+
+The magic system is designed but not yet implemented. See `plans/features/magic-system/` for the 25-phase implementation plan.
+
+### Overview
+- **Spells**: Instant-cast, mana-based, level+INT requirements
+- **Rituals**: Multi-turn channeling, component-based, no level requirement
+- 8 schools of magic (Evocation, Conjuration, Enchantment, Transmutation, Divination, Necromancy, Abjuration, Illusion)
+- Minimum 8 INT required for all magic
+
+### Planned Keybindings (Conflicts to Resolve)
+Current keybinding conflicts:
+- `C` is used for Crafting menu
+- `M` is used for World map
+
+Proposed alternatives:
+- `K` - Open spell casting menu
+- `Shift+K` - View known spells
+- `Shift+T` - Open ritual menu
+- `Shift+S` - Summon commands
+
+### Documentation
+- `docs/systems/magic-system.md` - System overview
+- `docs/data/spells.md` - Spell JSON format
+- `docs/data/rituals.md` - Ritual JSON format
+
+---
+
 ## Future Phases (Post-1.15)
 
 - Phase 1.16: UI Polish (shop UI, save/load UI, death screen, menu improvements)
 - Phase 1.17: Integration & Testing (full playtest, balance pass, bug fixes)
+- Phase 2.x: Magic System (25 implementation phases in `plans/features/magic-system/`)
 
 ---
 
@@ -661,6 +690,7 @@ docs/
 | `container-component.md` | `systems/components/container_component.gd` | Storage |
 | `resource-spawner.md` | `systems/resource_spawner.gd` | Resource placement |
 | `recipe-manager.md` | `autoload/recipe_manager.gd` | Recipe loading |
+| `magic-system.md` | `systems/magic_system.gd` | Spellcasting (planned) |
 
 ### Data Documentation Files
 
@@ -678,6 +708,8 @@ docs/
 | `structures.md` | `data/structures/` | Structure definitions |
 | `world-generation.md` | `data/world_generation_config.json` | World gen config |
 | `configuration.md` | Various | Game constants |
+| `spells.md` | `data/spells/` | Spell JSON format (planned) |
+| `rituals.md` | `data/rituals/` | Ritual JSON format (planned) |
 
 ### Update Rules
 

--- a/docs/data/rituals.md
+++ b/docs/data/rituals.md
@@ -1,0 +1,180 @@
+# Ritual Data Format
+
+Rituals are defined as JSON files in the `data/rituals/` directory.
+
+## Status: Not Yet Implemented
+
+This documentation will be updated as the ritual system is implemented in Phases 24-25.
+
+## Overview
+
+Rituals differ from spells in several ways:
+- Require multiple turns to channel
+- Consume material components
+- No level requirement (only INT)
+- Can be interrupted by damage
+- Generally more powerful effects
+
+## Directory Structure
+
+```
+data/rituals/
+├── enchant_item.json
+├── scrying.json
+├── resurrection.json
+├── summon_demon.json
+├── bind_soul.json
+└── ward_area.json
+```
+
+## JSON Schema
+
+```json
+{
+  "id": "ritual_id",
+  "name": "Display Name",
+  "description": "What the ritual does.",
+  "school": "transmutation",
+  "components": [
+    {"item_id": "mana_crystal", "quantity": 5},
+    {"item_id": "arcane_essence", "quantity": 2, "consumed": true}
+  ],
+  "channeling_turns": 10,
+  "requirements": {
+    "intelligence": 14,
+    "near_altar": true,
+    "night_only": false
+  },
+  "effects": {
+    "enchant_item": {
+      "enchantment_pool": ["sharpness", "protection"]
+    }
+  },
+  "failure_effects": {
+    "destroy_item_chance": 0.3,
+    "summon_hostile": false
+  },
+  "discovery_location": "ancient_library"
+}
+```
+
+## Property Reference
+
+### Core Properties
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| id | string | Yes | Unique ritual identifier |
+| name | string | Yes | Display name |
+| description | string | Yes | Ritual description |
+| school | string | Yes | Magic school |
+| channeling_turns | int | Yes | Turns required to complete |
+
+### Components
+
+Array of required materials:
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| item_id | string | - | Item identifier |
+| quantity | int | 1 | Number required |
+| consumed | bool | true | Whether component is consumed |
+
+### Requirements
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| intelligence | int | 8 | Minimum INT attribute |
+| near_altar | bool | false | Must be adjacent to altar |
+| night_only | bool | false | Can only perform at night |
+| near_corpse | bool | false | Requires corpse nearby |
+| target_low_health | bool | false | Target must be < 25% HP |
+
+### Effect Types
+
+#### Enchant Item
+```json
+"enchant_item": {
+  "enchantment_pool": ["sharpness", "protection", "mana_regen"]
+}
+```
+
+#### Reveal Map (Scrying)
+```json
+"reveal_map": {
+  "radius": 30,
+  "reveals_enemies": true,
+  "reveals_items": true
+}
+```
+
+#### Resurrect
+```json
+"resurrect": {
+  "health_percent": 25,
+  "temporary_weakness": true
+}
+```
+
+#### Summon
+```json
+"summon": {
+  "creature_id": "bound_demon",
+  "duration": 200,
+  "behavior": "aggressive"
+}
+```
+
+#### Bind Soul
+```json
+"bind_soul": {
+  "kills_target": true,
+  "creates_item": "filled_soul_gem"
+}
+```
+
+#### Create Ward
+```json
+"create_ward": {
+  "radius": 5,
+  "duration": 500,
+  "effects": ["blocks_undead", "blocks_demons", "alarm_on_entry"]
+}
+```
+
+### Failure Effects
+
+What happens if the ritual is interrupted:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| destroy_item_chance | float | Chance target item is destroyed (0.0-1.0) |
+| summon_hostile | bool | Summons hostile creature on failure |
+| summon_hostile_undead | bool | Summons hostile undead on failure |
+
+## Planned Rituals
+
+| Ritual | School | Channeling | Effect |
+|--------|--------|------------|--------|
+| Enchant Item | Transmutation | 10 turns | Add permanent enchantment to item |
+| Scrying | Divination | 5 turns | Reveal large map area |
+| Resurrection | Necromancy | 20 turns | Return fallen ally to life |
+| Summon Demon | Conjuration | 15 turns | Summon powerful demon ally |
+| Bind Soul | Necromancy | 8 turns | Trap creature's soul in gem |
+| Ward Area | Abjuration | 12 turns | Create protective barrier |
+
+## Learning Rituals
+
+Rituals are learned by finding and reading ritual tomes:
+- `ritual_tome_enchant` - Tome of Enchantment
+- `ritual_tome_scrying` - Tome of Far Sight
+- `ritual_tome_resurrection` - Book of Life
+- etc.
+
+Tomes are found in specific locations noted in the `discovery_location` field.
+
+## Related Documentation
+
+- [Magic System](../systems/magic-system.md)
+- [Spell Data Format](spells.md)
+- [Items Data Format](items.md) - For ritual components

--- a/docs/data/spells.md
+++ b/docs/data/spells.md
@@ -1,0 +1,257 @@
+# Spell Data Format
+
+Spells are defined as JSON files in `data/spells/{school}/` directories.
+
+## Status: Not Yet Implemented
+
+This documentation will be updated as spell data loading is implemented in Phase 2.
+
+## Directory Structure
+
+```
+data/spells/
+├── evocation/
+│   ├── spark.json
+│   ├── flame_bolt.json
+│   └── fireball.json
+├── conjuration/
+│   ├── create_light.json
+│   └── summon_creature.json
+├── enchantment/
+│   ├── charm.json
+│   └── fear.json
+├── transmutation/
+│   ├── stone_skin.json
+│   └── wall_to_mud.json
+├── divination/
+│   ├── detect_magic.json
+│   └── identify.json
+├── necromancy/
+│   ├── drain_life.json
+│   └── poison.json
+├── abjuration/
+│   ├── shield.json
+│   └── remove_curse.json
+└── illusion/
+    └── minor_illusion.json
+```
+
+## JSON Schema
+
+```json
+{
+  "id": "spell_id",
+  "name": "Display Name",
+  "description": "What the spell does.",
+  "school": "evocation",
+  "level": 1,
+  "mana_cost": 5,
+  "requirements": {
+    "character_level": 1,
+    "intelligence": 8
+  },
+  "targeting": {
+    "mode": "ranged",
+    "range": 6,
+    "requires_los": true,
+    "aoe_radius": 0,
+    "aoe_shape": "circle"
+  },
+  "effects": {
+    "damage": {
+      "type": "fire",
+      "base": 10,
+      "scaling": 2
+    }
+  },
+  "save": {
+    "type": "DEX",
+    "on_success": "half_damage"
+  },
+  "concentration": false,
+  "cooldown": 0,
+  "cast_message": "Flames erupt from your hands!"
+}
+```
+
+## Property Reference
+
+### Core Properties
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| id | string | Yes | Unique spell identifier |
+| name | string | Yes | Display name |
+| description | string | Yes | Spell description |
+| school | string | Yes | Magic school (see list below) |
+| level | int | Yes | Spell level (0-10, 0 = cantrip) |
+| mana_cost | int | Yes | Mana required to cast |
+
+### Requirements
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| character_level | int | 1 | Minimum player level |
+| intelligence | int | 8 | Minimum INT attribute |
+
+### Targeting
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| mode | string | "self" | Targeting mode (see below) |
+| range | int | 0 | Maximum range in tiles |
+| requires_los | bool | true | Requires line of sight |
+| aoe_radius | int | 0 | Area of effect radius |
+| aoe_shape | string | "circle" | AOE shape |
+| requires_empty | bool | false | Target tile must be empty |
+
+### Targeting Modes
+
+- `self` - Affects caster only
+- `ranged` - Single target at range
+- `tile` - Targets a tile (for terrain/summon)
+- `aoe` - Area of effect at target location
+- `self_or_ally` - Caster or adjacent ally
+
+### Effect Types
+
+Effects are defined in the `effects` object. Multiple effect types can be combined.
+
+#### Damage Effect
+```json
+"damage": {
+  "type": "fire",
+  "base": 10,
+  "scaling": 2
+}
+```
+- `type`: fire, ice, lightning, poison, necrotic, holy, physical
+- `base`: Base damage amount
+- `scaling`: Additional damage per caster level above spell level
+
+#### Buff/Debuff Effect
+```json
+"buff": {
+  "id": "shield_effect",
+  "stat": "armor",
+  "modifier": 5,
+  "duration": 50
+}
+```
+
+#### DoT Effect
+```json
+"dot": {
+  "type": "poison",
+  "damage_per_turn": 3,
+  "duration": 10
+}
+```
+
+#### Mind Effect
+```json
+"mind_effect": "charm"
+```
+Values: charm, fear, calm, enrage
+
+#### Summon Effect
+```json
+"summon": {
+  "creature_id": "summoned_wolf",
+  "base_duration": 50,
+  "duration_per_level": 10
+}
+```
+
+### Saving Throws
+
+| Property | Type | Description |
+|----------|------|-------------|
+| type | string | Save attribute (STR, DEX, CON, INT, WIS, CHA) |
+| on_success | string | Effect on successful save |
+
+On Success Values:
+- `no_effect` - Spell completely resisted
+- `half_damage` - Take half damage
+- `half_duration` - Effect lasts half as long
+
+### Schools of Magic
+
+- `evocation` - Damage and energy manipulation
+- `conjuration` - Creation and summoning
+- `enchantment` - Mind control and influence
+- `transmutation` - Transformation and alteration
+- `divination` - Knowledge and detection
+- `necromancy` - Death and undead
+- `abjuration` - Protection and warding
+- `illusion` - Deception and trickery
+
+## Examples
+
+### Cantrip (Level 0)
+```json
+{
+  "id": "spark",
+  "name": "Spark",
+  "description": "A tiny arc of electricity.",
+  "school": "evocation",
+  "level": 0,
+  "mana_cost": 0,
+  "requirements": {"intelligence": 8},
+  "targeting": {"mode": "ranged", "range": 3},
+  "effects": {
+    "damage": {"type": "lightning", "base": 2, "scaling": 0}
+  }
+}
+```
+
+### Damage Spell
+```json
+{
+  "id": "fireball",
+  "name": "Fireball",
+  "description": "A ball of fire explodes at the target location.",
+  "school": "evocation",
+  "level": 7,
+  "mana_cost": 45,
+  "requirements": {"character_level": 7, "intelligence": 14},
+  "targeting": {
+    "mode": "aoe",
+    "range": 8,
+    "aoe_radius": 3,
+    "requires_los": true
+  },
+  "effects": {
+    "damage": {"type": "fire", "base": 25, "scaling": 5}
+  },
+  "save": {"type": "DEX", "on_success": "half_damage"}
+}
+```
+
+### Buff Spell
+```json
+{
+  "id": "shield",
+  "name": "Shield",
+  "description": "Create a magical barrier around yourself.",
+  "school": "abjuration",
+  "level": 2,
+  "mana_cost": 8,
+  "requirements": {"character_level": 2, "intelligence": 9},
+  "targeting": {"mode": "self"},
+  "effects": {
+    "buff": {
+      "id": "shield_effect",
+      "stat": "armor",
+      "modifier": 5,
+      "duration": 30
+    }
+  }
+}
+```
+
+## Related Documentation
+
+- [Magic System](../systems/magic-system.md)
+- [Items Data Format](items.md) - For scrolls, wands, staves
+- [Enemies Data Format](enemies.md) - For enemy spellcasters

--- a/docs/systems/magic-system.md
+++ b/docs/systems/magic-system.md
@@ -1,0 +1,66 @@
+# Magic System
+
+The magic system provides spellcasting and ritual mechanics for the player.
+
+## Overview
+
+The magic system consists of two main components:
+- **Spells** - Instant-cast abilities that consume mana
+- **Rituals** - Multi-turn channeled abilities that consume components
+
+## Status: Not Yet Implemented
+
+This documentation will be updated as each magic system phase is implemented.
+
+## Planned Features
+
+### Mana System
+- Mana pool: Base 30 + (INT × 5)
+- Regenerates during rest
+- Required for all spellcasting
+
+### Spellcasting
+- Minimum 8 INT required for all magic
+- Spells require level + INT to cast
+- Spell schools: Evocation, Conjuration, Enchantment, Transmutation, Divination, Necromancy, Abjuration, Illusion
+- Failure modes: Fizzle, Backfire, Wild Magic
+
+### Magic Items
+- Spellbooks - Required to store learned spells
+- Scrolls - Cast spells without knowing them
+- Wands - Charged items with limited uses
+- Staves - Melee weapons with casting bonuses
+- Magic Rings/Amulets - Passive effect equipment
+
+### Rituals
+- Multi-turn channeling
+- Component consumption
+- No level requirement (only INT)
+- Interruptible by damage
+
+## Keybindings
+
+**Note:** These are planned keybindings. Some may conflict with existing controls and will be adjusted during implementation.
+
+Conflicts identified:
+- `C` is used for Crafting menu
+- `M` is used for World map
+
+Proposed keybindings:
+| Key | Action |
+|-----|--------|
+| K | Open spell casting menu |
+| Shift+K | View known spells |
+| Shift+T | Open ritual menu (T alone is Talk) |
+| Shift+S | Summon commands (if summons active) |
+
+## Related Documentation
+
+- [Spell Data Format](../data/spells.md)
+- [Ritual Data Format](../data/rituals.md)
+- [Spell Manager](spell-manager.md) (to be created)
+- [Ritual System](ritual-system.md) (to be created)
+
+## Implementation Phases
+
+The magic system is implemented across 25 phases. See `plans/features/magic-system/` for detailed implementation plans.


### PR DESCRIPTION
Phase 00 of magic system implementation - documentation setup:

- Create docs/systems/magic-system.md with system overview
- Create docs/data/spells.md with spell JSON format documentation
- Create docs/data/rituals.md with ritual JSON format documentation
- Update CLAUDE.md with magic system section and keybinding notes
- Add magic system docs to documentation tables

Identified keybinding conflicts:
- C (crafting) and M (map) are already used
- Proposed alternatives: K for spells, Shift+T for rituals

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>