### PR TITLE
feat(magic): Implement Phase 03 - Spellbook & Spell Learning

### DIFF
--- a/autoload/event_bus.gd
+++ b/autoload/event_bus.gd
@@ -65,6 +65,12 @@ signal mana_changed(old_value: float, new_value: float, max_value: float)
 @warning_ignore("unused_signal")
 signal mana_depleted()
 
+# Spell signals (magic system)
+@warning_ignore("unused_signal")
+signal spell_learned(spell_id: String)
+@warning_ignore("unused_signal")
+signal spell_cast(caster, spell, targets: Array, result: Dictionary)
+
 # Inventory signals
 @warning_ignore("unused_signal")
 signal item_picked_up(item)  # Item

--- a/autoload/save_manager.gd
+++ b/autoload/save_manager.gd
@@ -233,7 +233,8 @@ func _serialize_player() -> Dictionary:
 		"available_skill_points": player.available_skill_points,
 		"available_ability_points": player.available_ability_points,
 		"skills": player.skills.duplicate(),
-		"known_recipes": player.known_recipes.duplicate()
+		"known_recipes": player.known_recipes.duplicate(),
+		"known_spells": player.known_spells.duplicate()
 	}
 
 ## Serialize survival stats
@@ -538,6 +539,12 @@ func _deserialize_player(player_data: Dictionary):
 	player.known_recipes.clear()
 	for recipe_id in player_data.known_recipes:
 		player.known_recipes.append(recipe_id)
+
+	# Restore known spells (clear and append to maintain Array[String] type)
+	player.known_spells.clear()
+	if player_data.has("known_spells"):
+		for spell_id in player_data.known_spells:
+			player.known_spells.append(spell_id)
 
 	print("SaveManager: Player deserialized")
 

--- a/data/items/books/spellbook.json
+++ b/data/items/books/spellbook.json
@@ -1,0 +1,15 @@
+{
+  "id": "spellbook",
+  "name": "Spellbook",
+  "description": "A leather-bound tome for recording arcane knowledge. Required to learn and cast spells.",
+  "category": "book",
+  "subtype": "spellbook",
+  "flags": {
+    "spellbook": true
+  },
+  "weight": 2.0,
+  "value": 50,
+  "max_stack": 1,
+  "ascii_char": "+",
+  "ascii_color": "#8844AA"
+}

--- a/data/items/books/tome_of_heal.json
+++ b/data/items/books/tome_of_heal.json
@@ -1,0 +1,17 @@
+{
+  "id": "tome_of_heal",
+  "name": "Tome of Healing",
+  "description": "A sacred text on channeling restorative energies. Reading this will inscribe the spell into your spellbook.",
+  "category": "book",
+  "subtype": "spell_tome",
+  "flags": {
+    "readable": true,
+    "magical": true
+  },
+  "teaches_spell": "heal",
+  "weight": 1.0,
+  "value": 100,
+  "max_stack": 1,
+  "ascii_char": "+",
+  "ascii_color": "#44FF44"
+}

--- a/data/items/books/tome_of_light.json
+++ b/data/items/books/tome_of_light.json
@@ -1,0 +1,17 @@
+{
+  "id": "tome_of_light",
+  "name": "Tome of Light",
+  "description": "A primer on the most basic evocation - summoning light. Reading this will inscribe the cantrip into your spellbook.",
+  "category": "book",
+  "subtype": "spell_tome",
+  "flags": {
+    "readable": true,
+    "magical": true
+  },
+  "teaches_spell": "light",
+  "weight": 0.5,
+  "value": 25,
+  "max_stack": 1,
+  "ascii_char": "+",
+  "ascii_color": "#FFFFAA"
+}

--- a/data/items/books/tome_of_shield.json
+++ b/data/items/books/tome_of_shield.json
@@ -1,0 +1,17 @@
+{
+  "id": "tome_of_shield",
+  "name": "Tome of Shield",
+  "description": "A guide to creating magical barriers. Reading this will inscribe the spell into your spellbook.",
+  "category": "book",
+  "subtype": "spell_tome",
+  "flags": {
+    "readable": true,
+    "magical": true
+  },
+  "teaches_spell": "shield",
+  "weight": 1.0,
+  "value": 75,
+  "max_stack": 1,
+  "ascii_char": "+",
+  "ascii_color": "#4444FF"
+}

--- a/data/items/books/tome_of_spark.json
+++ b/data/items/books/tome_of_spark.json
@@ -1,0 +1,17 @@
+{
+  "id": "tome_of_spark",
+  "name": "Tome of Spark",
+  "description": "An instructional text on channeling lightning. Reading this will inscribe the spell into your spellbook.",
+  "category": "book",
+  "subtype": "spell_tome",
+  "flags": {
+    "readable": true,
+    "magical": true
+  },
+  "teaches_spell": "spark",
+  "weight": 1.0,
+  "value": 75,
+  "max_stack": 1,
+  "ascii_char": "+",
+  "ascii_color": "#FFFF00"
+}

--- a/docs/systems/input-handler.md
+++ b/docs/systems/input-handler.md
@@ -81,6 +81,7 @@ var current_target: Entity = null
 | C | Open crafting |
 | B | Toggle build mode |
 | M | Toggle world map |
+| Shift+M | Toggle spellbook |
 | P | Character sheet |
 | F1 / ? | Help screen |
 | L | Look mode |

--- a/docs/systems/magic-system.md
+++ b/docs/systems/magic-system.md
@@ -12,6 +12,7 @@ The magic system consists of two main components:
 
 - **Phase 01** (Mana System) - Implemented
 - **Phase 02** (Spell Data & Manager) - Implemented
+- **Phase 03** (Spellbook & Spell Learning) - Implemented
 
 Remaining phases are planned.
 
@@ -113,6 +114,80 @@ SpellManager.calculate_spell_duration(spell, caster) -> int
 
 For spell JSON format, see [Spell Data Format](../data/spells.md).
 
+## Spellbook & Spell Learning (Implemented)
+
+Players must possess a spellbook item to learn and access spells.
+
+### Spellbook Item
+
+A spellbook is a book item with the `spellbook` flag:
+```json
+{
+  "id": "spellbook",
+  "category": "book",
+  "flags": {"readable": true, "magical": true, "spellbook": true}
+}
+```
+
+### Player Known Spells
+
+- `known_spells: Array[String]` - List of learned spell IDs
+- Persisted in save/load
+- Accessed via `player.get_known_spells()` which returns full Spell objects
+
+### Learning Spells
+
+Spells are learned from **Spell Tomes** - book items with `teaches_spell` property:
+
+```json
+{
+  "id": "tome_of_spark",
+  "name": "Tome of Spark",
+  "category": "book",
+  "subtype": "spell_tome",
+  "teaches_spell": "spark"
+}
+```
+
+**Learning Requirements:**
+- Player must have a spellbook in inventory
+- Player must meet spell's INT requirement
+- Player must meet spell's level requirement
+- Player must not already know the spell
+- Spell tome is consumed on successful learning
+
+### Player Methods
+
+```gdscript
+player.has_spellbook() -> bool       # Check for spellbook item
+player.knows_spell(spell_id) -> bool # Check if spell is known
+player.learn_spell(spell_id) -> bool # Learn a new spell
+player.get_known_spells() -> Array   # Get all known Spell objects
+```
+
+### EventBus Signals
+
+```gdscript
+signal spell_learned(spell_id: String)
+signal spell_cast(caster, spell, targets: Array, result: Dictionary)
+```
+
+### Spell List UI
+
+Open with **Shift+M** to view known spells:
+- Shows all learned spells with name, school, level, mana cost
+- Detail panel shows requirements and whether player can cast
+- School colors: Evocation (orange), Conjuration (purple), etc.
+
+### Current Spell Tomes
+
+| Tome | Teaches | Value |
+|------|---------|-------|
+| Tome of Light | light cantrip | 25 |
+| Tome of Spark | spark (Lv1) | 75 |
+| Tome of Healing | heal (Lv1) | 100 |
+| Tome of Shield | shield (Lv1) | 75 |
+
 ## Planned Features
 
 ### Spellcasting
@@ -136,17 +211,15 @@ For spell JSON format, see [Spell Data Format](../data/spells.md).
 
 ## Keybindings
 
-**Note:** These are planned keybindings. Some may conflict with existing controls and will be adjusted during implementation.
+### Implemented
+| Key | Action |
+|-----|--------|
+| Shift+M | Open spellbook (view known spells) |
 
-Conflicts identified:
-- `C` is used for Crafting menu
-- `M` is used for World map
-
-Proposed keybindings:
+### Planned
 | Key | Action |
 |-----|--------|
 | K | Open spell casting menu |
-| Shift+K | View known spells |
 | Shift+T | Open ritual menu (T alone is Talk) |
 | Shift+S | Summon commands (if summons active) |
 

--- a/entities/player.gd
+++ b/entities/player.gd
@@ -19,6 +19,7 @@ var perception_range: int = 10
 var survival: SurvivalSystem = null
 var inventory: Inventory = null
 var known_recipes: Array[String] = []  # Array of recipe IDs the player has discovered
+var known_spells: Array[String] = []  # Array of spell IDs the player has learned
 var gold: int = 25  # Player's gold currency
 
 # Experience and Leveling
@@ -607,6 +608,53 @@ func get_craftable_recipes() -> Array:
 		if recipe and recipe.has_requirements(inventory, near_fire):
 			result.append(recipe)
 
+	return result
+
+# =============================================================================
+# SPELLBOOK & SPELL LEARNING
+# =============================================================================
+
+## Check if player has a spellbook in inventory
+func has_spellbook() -> bool:
+	if not inventory:
+		return false
+	return inventory.has_item_with_flag("spellbook")
+
+## Check if player knows a specific spell
+func knows_spell(spell_id: String) -> bool:
+	return spell_id in known_spells
+
+## Learn a new spell (requires spellbook)
+## Returns true if spell was successfully learned
+func learn_spell(spell_id: String) -> bool:
+	if not has_spellbook():
+		return false
+	if knows_spell(spell_id):
+		return false
+	var spell = SpellManager.get_spell(spell_id)
+	if spell == null:
+		return false
+	known_spells.append(spell_id)
+	EventBus.spell_learned.emit(spell_id)
+	print("Player learned spell: ", spell_id)
+	return true
+
+## Get all spells the player knows
+func get_known_spells() -> Array:
+	var result: Array = []
+	for spell_id in known_spells:
+		var spell = SpellManager.get_spell(spell_id)
+		if spell:
+			result.append(spell)
+	return result
+
+## Get spells the player can currently cast (knows spell + meets requirements)
+func get_castable_spells() -> Array:
+	var result: Array = []
+	for spell_id in known_spells:
+		var spell = SpellManager.get_spell(spell_id)
+		if spell and SpellManager.can_cast(self, spell).can_cast:
+			result.append(spell)
 	return result
 
 ## Open a door at the given position

--- a/scenes/game.gd
+++ b/scenes/game.gd
@@ -34,6 +34,7 @@ var help_screen: Control = null
 var world_map_screen: Control = null
 var fast_travel_screen: Control = null
 var rest_menu: Control = null
+var spell_list_screen: Control = null
 var auto_pickup_enabled: bool = true  # Toggle for automatic item pickup
 
 # Rest system state
@@ -70,6 +71,7 @@ const TrainingScreenScene = preload("res://ui/training_screen.tscn")
 const NpcMenuScreenScene = preload("res://ui/npc_menu_screen.tscn")
 const PauseMenuScene = preload("res://ui/pause_menu.tscn")
 const DeathScreenScene = preload("res://ui/death_screen.tscn")
+const SpellListScreenScene = preload("res://ui/spell_list_screen.tscn")
 
 func _ready() -> void:
 	# Get renderer reference
@@ -125,6 +127,9 @@ func _ready() -> void:
 
 	# Create rest menu
 	_setup_rest_menu()
+
+	# Create spell list screen
+	_setup_spell_list_screen()
 
 	# Only initialize new game if not loading from save
 	if not GameManager.is_loading_save:
@@ -389,6 +394,19 @@ func _setup_rest_menu() -> void:
 		print("[Game] Rest menu scene instantiated and added to HUD")
 	else:
 		print("[Game] ERROR: Could not load rest_menu.tscn scene")
+
+## Setup spell list screen
+func _setup_spell_list_screen() -> void:
+	print("[Game] Setting up spell list screen from scene...")
+	if SpellListScreenScene:
+		spell_list_screen = SpellListScreenScene.instantiate()
+		spell_list_screen.name = "SpellListScreen"
+		hud.add_child(spell_list_screen)
+		if spell_list_screen.has_signal("closed"):
+			spell_list_screen.closed.connect(_on_spell_list_closed)
+		print("[Game] Spell list screen scene instantiated and added to HUD")
+	else:
+		print("[Game] ERROR: Could not load spell_list_screen.tscn scene")
 
 ## Give player some starter items
 func _give_starter_items() -> void:
@@ -1677,6 +1695,16 @@ func toggle_world_map() -> void:
 			world_map_screen.open()
 			input_handler.ui_blocking_input = true
 
+## Toggle spell list (called from input handler via Shift+M)
+func toggle_spell_list() -> void:
+	if spell_list_screen and player:
+		if spell_list_screen.visible:
+			spell_list_screen.hide()
+			input_handler.ui_blocking_input = false
+		else:
+			spell_list_screen.open(player)
+			input_handler.ui_blocking_input = true
+
 ## Open container screen (called from input handler)
 func open_container_screen(structure: Structure) -> void:
 	if container_screen and player:
@@ -1894,6 +1922,10 @@ func _on_help_screen_closed() -> void:
 
 ## Called when world map is closed
 func _on_world_map_closed() -> void:
+	input_handler.ui_blocking_input = false
+
+## Called when spell list is closed
+func _on_spell_list_closed() -> void:
 	input_handler.ui_blocking_input = false
 
 ## Toggle fast travel screen (called from input handler)

--- a/systems/input_handler.gd
+++ b/systems/input_handler.gd
@@ -596,7 +596,10 @@ func _unhandled_input(event: InputEvent) -> void:
 		elif event.keycode == KEY_T and not event.shift_pressed:  # T - talk/interact with NPC
 			_try_interact_npc()
 			get_viewport().set_input_as_handled()
-		elif event.keycode == KEY_M:  # M - toggle world map
+		elif event.keycode == KEY_M and event.shift_pressed:  # Shift+M - toggle spellbook
+			_toggle_spell_list()
+			get_viewport().set_input_as_handled()
+		elif event.keycode == KEY_M and not event.shift_pressed:  # M - toggle world map
 			_toggle_world_map()
 			get_viewport().set_input_as_handled()
 		elif event.keycode == KEY_H:  # H key - harvest (prompts for direction)
@@ -793,6 +796,12 @@ func _toggle_world_map() -> void:
 	var game = get_parent()
 	if game and game.has_method("toggle_world_map"):
 		game.toggle_world_map()
+
+## Toggle spell list screen
+func _toggle_spell_list() -> void:
+	var game = get_parent()
+	if game and game.has_method("toggle_spell_list"):
+		game.toggle_spell_list()
 
 ## Interact with structure at player position
 func _interact_with_structure() -> void:

--- a/systems/inventory_system.gd
+++ b/systems/inventory_system.gd
@@ -158,6 +158,17 @@ func remove_item_by_id(item_id: String, count: int = 1) -> int:
 func has_item(item_id: String, count: int = 1) -> bool:
 	return get_item_count(item_id) >= count
 
+## Check if inventory contains any item with a specific flag
+func has_item_with_flag(flag_name: String) -> bool:
+	for item in items:
+		if item.has_flag(flag_name):
+			return true
+	# Also check equipped items
+	for slot in equipment.values():
+		if slot and slot.has_flag(flag_name):
+			return true
+	return false
+
 ## Get total count of an item by ID
 func get_item_count(item_id: String) -> int:
 	var total = 0

--- a/ui/help_screen.gd
+++ b/ui/help_screen.gd
@@ -100,6 +100,7 @@ func _build_help_content() -> void:
 	_add_section_header("== MENUS & UI ==")
 	_add_keybind("P", "Character sheet")
 	_add_keybind("M", "World map")
+	_add_keybind("Shift+M", "Spellbook (view known spells)")
 	_add_keybind("Z", "Fast travel to visited locations")
 	_add_keybind("? or F1", "This help screen")
 	_add_keybind("ESC", "Pause menu / close UI")

--- a/ui/spell_list_screen.gd
+++ b/ui/spell_list_screen.gd
@@ -1,0 +1,394 @@
+extends Control
+
+## SpellListScreen - UI for viewing known spells in the player's spellbook
+##
+## Shows all spells the player has learned, organized as a list with details.
+## Requires a spellbook item in inventory to access.
+
+signal closed()
+
+@onready var title_label: Label = $Panel/MarginContainer/VBoxContainer/TitleLabel
+@onready var mana_label: Label = $Panel/MarginContainer/VBoxContainer/HeaderPanel/ManaLabel
+@onready var spell_list: VBoxContainer = $Panel/MarginContainer/VBoxContainer/ContentContainer/SpellListPanel/ScrollContainer/SpellList
+@onready var spell_scroll: ScrollContainer = $Panel/MarginContainer/VBoxContainer/ContentContainer/SpellListPanel/ScrollContainer
+@onready var spell_list_title: Label = $Panel/MarginContainer/VBoxContainer/ContentContainer/SpellListPanel/SpellListTitle
+
+# Detail panel elements
+@onready var spell_name_label: Label = $Panel/MarginContainer/VBoxContainer/DetailPanel/DetailVBox/DetailColumns/NameColumn/SpellName
+@onready var spell_desc_label: Label = $Panel/MarginContainer/VBoxContainer/DetailPanel/DetailVBox/DetailColumns/NameColumn/SpellDesc
+@onready var stat_line_1: Label = $Panel/MarginContainer/VBoxContainer/DetailPanel/DetailVBox/DetailColumns/StatsColumn/StatLine1
+@onready var stat_line_2: Label = $Panel/MarginContainer/VBoxContainer/DetailPanel/DetailVBox/DetailColumns/StatsColumn/StatLine2
+@onready var stat_line_3: Label = $Panel/MarginContainer/VBoxContainer/DetailPanel/DetailVBox/DetailColumns/StatsColumn/StatLine3
+@onready var req_line_1: Label = $Panel/MarginContainer/VBoxContainer/DetailPanel/DetailVBox/DetailColumns/ReqColumn/ReqLine1
+@onready var req_line_2: Label = $Panel/MarginContainer/VBoxContainer/DetailPanel/DetailVBox/DetailColumns/ReqColumn/ReqLine2
+@onready var req_line_3: Label = $Panel/MarginContainer/VBoxContainer/DetailPanel/DetailVBox/DetailColumns/ReqColumn/ReqLine3
+@onready var footer_label: Label = $Panel/MarginContainer/VBoxContainer/DetailPanel/DetailVBox/FooterRow/FooterLabel
+
+var player: Player = null
+var spells: Array = []
+var selected_index: int = 0
+
+# Colors (matching inventory screen)
+const COLOR_SELECTED = Color(0.2, 0.4, 0.3, 1.0)
+const COLOR_NORMAL = Color(0.7, 0.7, 0.7, 1.0)
+const COLOR_EMPTY = Color(0.4, 0.4, 0.4, 1.0)
+const COLOR_HIGHLIGHT = Color(1.0, 1.0, 0.6, 1.0)
+const COLOR_MANA = Color(0.3, 0.6, 1.0, 1.0)
+const COLOR_REQ_MET = Color(0.5, 1.0, 0.5, 1.0)
+const COLOR_REQ_NOT_MET = Color(1.0, 0.5, 0.5, 1.0)
+
+# School abbreviations
+const SCHOOL_ABBREVS = {
+	"evocation": "Evo",
+	"conjuration": "Con",
+	"enchantment": "Ench",
+	"transmutation": "Trans",
+	"divination": "Div",
+	"necromancy": "Nec",
+	"abjuration": "Abj",
+	"illusion": "Ill"
+}
+
+# School colors for visual distinction
+const SCHOOL_COLORS = {
+	"evocation": Color(1.0, 0.5, 0.3),    # Orange-red (fire/energy)
+	"conjuration": Color(0.7, 0.3, 1.0),   # Purple (summoning)
+	"enchantment": Color(1.0, 0.8, 0.3),   # Gold (mind magic)
+	"transmutation": Color(0.3, 0.8, 0.3), # Green (change)
+	"divination": Color(0.3, 0.8, 1.0),    # Cyan (knowledge)
+	"necromancy": Color(0.6, 0.6, 0.6),    # Gray (death)
+	"abjuration": Color(0.3, 0.6, 1.0),    # Blue (protection)
+	"illusion": Color(0.9, 0.5, 0.9)       # Pink (deception)
+}
+
+func _ready() -> void:
+	hide()
+	process_mode = Node.PROCESS_MODE_ALWAYS
+
+func _input(event: InputEvent) -> void:
+	if not visible:
+		return
+
+	if event is InputEventKey and event.pressed and not event.echo:
+		# Escape always closes
+		if event.keycode == KEY_ESCAPE:
+			_close()
+			get_viewport().set_input_as_handled()
+			return
+
+		# Shift+M toggles spellbook (same key combo that opens it)
+		if event.keycode == KEY_M and event.shift_pressed:
+			_close()
+			get_viewport().set_input_as_handled()
+			return
+
+		match event.keycode:
+			KEY_UP:
+				_navigate(-1)
+				get_viewport().set_input_as_handled()
+			KEY_DOWN:
+				_navigate(1)
+				get_viewport().set_input_as_handled()
+
+func open(p: Player) -> void:
+	player = p
+	selected_index = 0
+
+	# Check if player has spellbook
+	if not player or not player.has_spellbook():
+		_show_no_spellbook_message()
+		show()
+		return
+
+	# Get known spells
+	spells = player.get_known_spells()
+
+	refresh()
+	show()
+
+func _close() -> void:
+	hide()
+	closed.emit()
+
+func refresh() -> void:
+	if not player:
+		return
+
+	_update_mana_display()
+	_update_spell_list()
+	_update_selection()
+
+func _show_no_spellbook_message() -> void:
+	# Clear spell list
+	for child in spell_list.get_children():
+		spell_list.remove_child(child)
+		child.free()
+
+	# Add no spellbook message
+	var label = Label.new()
+	label.text = "You need a spellbook to access your spells"
+	label.add_theme_color_override("font_color", COLOR_REQ_NOT_MET)
+	label.add_theme_font_size_override("font_size", 14)
+	label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	spell_list.add_child(label)
+
+	# Update header
+	if mana_label:
+		mana_label.text = "No Spellbook"
+		mana_label.add_theme_color_override("font_color", COLOR_REQ_NOT_MET)
+
+	if spell_list_title:
+		spell_list_title.text = "══ SPELLBOOK ══"
+
+	# Clear details
+	_clear_detail_panel()
+	spells = []
+
+func _update_mana_display() -> void:
+	if not player or not player.survival:
+		return
+
+	var current_mana = int(player.survival.mana)
+	var max_mana = int(player.survival.get_max_mana())
+
+	if mana_label:
+		mana_label.text = "Mana: %d / %d" % [current_mana, max_mana]
+		mana_label.add_theme_color_override("font_color", COLOR_MANA)
+
+func _update_spell_list() -> void:
+	if not spell_list:
+		return
+
+	# Clear existing (use free() instead of queue_free() for immediate removal)
+	for child in spell_list.get_children():
+		spell_list.remove_child(child)
+		child.free()
+
+	# Update title with spell count
+	if spell_list_title:
+		spell_list_title.text = "══ KNOWN SPELLS (%d) ══" % spells.size()
+
+	# Reset scroll position to top
+	if spell_scroll:
+		spell_scroll.scroll_vertical = 0
+
+	if spells.is_empty():
+		var label = Label.new()
+		label.text = "  (No spells learned)"
+		label.add_theme_color_override("font_color", COLOR_EMPTY)
+		label.add_theme_font_size_override("font_size", 13)
+		spell_list.add_child(label)
+	else:
+		for spell in spells:
+			var container = _create_spell_row(spell)
+			spell_list.add_child(container)
+
+func _create_spell_row(spell) -> HBoxContainer:
+	var container = HBoxContainer.new()
+	container.add_theme_constant_override("separation", 6)
+	container.set_meta("spell", spell)
+
+	# Icon
+	var icon = Label.new()
+	icon.name = "Icon"
+	icon.custom_minimum_size = Vector2(20, 0)
+	icon.add_theme_font_size_override("font_size", 14)
+	icon.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	icon.text = spell.ascii_char if spell.ascii_char else "*"
+	icon.add_theme_color_override("font_color", spell.get_color())
+	container.add_child(icon)
+
+	# Name
+	var name_label = Label.new()
+	name_label.name = "Name"
+	name_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	name_label.add_theme_font_size_override("font_size", 13)
+	name_label.text = spell.name
+	name_label.add_theme_color_override("font_color", COLOR_NORMAL)
+	container.add_child(name_label)
+
+	# School abbreviation
+	var school_label = Label.new()
+	school_label.name = "School"
+	school_label.custom_minimum_size = Vector2(40, 0)
+	school_label.add_theme_font_size_override("font_size", 12)
+	school_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	school_label.text = SCHOOL_ABBREVS.get(spell.school, spell.school.substr(0, 3).capitalize())
+	var school_color = SCHOOL_COLORS.get(spell.school, COLOR_NORMAL)
+	school_label.add_theme_color_override("font_color", school_color)
+	container.add_child(school_label)
+
+	# Level and mana cost
+	var info_label = Label.new()
+	info_label.name = "Info"
+	info_label.custom_minimum_size = Vector2(70, 0)
+	info_label.add_theme_font_size_override("font_size", 12)
+	info_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
+	var level_text = "Cantrip" if spell.level == 0 else "Lv%d" % spell.level
+	info_label.text = "%s %dMP" % [level_text, spell.mana_cost]
+	info_label.add_theme_color_override("font_color", Color(0.6, 0.6, 0.6))
+	container.add_child(info_label)
+
+	return container
+
+func _update_selection() -> void:
+	# Reset all highlights
+	for i in range(spell_list.get_child_count()):
+		var child = spell_list.get_child(i)
+		_set_row_highlight(child, false)
+
+	# Highlight selected if we have spells
+	if spells.size() > 0 and selected_index >= 0 and selected_index < spell_list.get_child_count():
+		var selected_row = spell_list.get_child(selected_index)
+		if selected_row is HBoxContainer:
+			_set_row_highlight(selected_row, true)
+			# Scroll to keep selected spell visible
+			_scroll_to_spell(selected_row)
+
+	_update_detail_panel()
+
+func _set_row_highlight(row: Control, highlighted: bool) -> void:
+	if row is HBoxContainer:
+		var name_node = row.get_node_or_null("Name")
+		if name_node and name_node is Label:
+			if highlighted:
+				name_node.text = "► " + name_node.text.trim_prefix("► ")
+				name_node.add_theme_color_override("font_color", COLOR_HIGHLIGHT)
+			else:
+				name_node.text = name_node.text.trim_prefix("► ")
+				name_node.add_theme_color_override("font_color", COLOR_NORMAL)
+
+func _scroll_to_spell(spell_row: Control) -> void:
+	if not spell_scroll or not spell_row or not is_instance_valid(spell_row):
+		return
+
+	_scroll_to_spell_deferred.call_deferred(spell_row)
+
+func _scroll_to_spell_deferred(spell_row: Control) -> void:
+	if not spell_scroll or not spell_row or not is_instance_valid(spell_row):
+		return
+
+	var item_top = spell_row.position.y
+	var item_bottom = item_top + spell_row.size.y
+
+	var scroll_top = spell_scroll.scroll_vertical
+	var scroll_bottom = scroll_top + spell_scroll.size.y
+
+	if item_top < scroll_top:
+		spell_scroll.scroll_vertical = int(item_top)
+	elif item_bottom > scroll_bottom:
+		spell_scroll.scroll_vertical = int(item_bottom - spell_scroll.size.y)
+
+func _update_detail_panel() -> void:
+	if spells.is_empty() or selected_index < 0 or selected_index >= spells.size():
+		_clear_detail_panel()
+		return
+
+	var spell = spells[selected_index]
+	_populate_spell_details(spell)
+
+func _clear_detail_panel() -> void:
+	if spell_name_label:
+		spell_name_label.text = "No spell selected"
+		spell_name_label.add_theme_color_override("font_color", COLOR_EMPTY)
+	if spell_desc_label:
+		spell_desc_label.text = "Learn spells from tomes or scrolls"
+	if stat_line_1:
+		stat_line_1.text = ""
+	if stat_line_2:
+		stat_line_2.text = ""
+	if stat_line_3:
+		stat_line_3.text = ""
+	if req_line_1:
+		req_line_1.text = ""
+	if req_line_2:
+		req_line_2.text = ""
+	if req_line_3:
+		req_line_3.text = ""
+	if footer_label:
+		footer_label.text = "[Esc/Shift+M] Close"
+
+func _populate_spell_details(spell) -> void:
+	# Name and description
+	if spell_name_label:
+		spell_name_label.text = spell.name
+		spell_name_label.add_theme_color_override("font_color", spell.get_color())
+
+	if spell_desc_label:
+		spell_desc_label.text = spell.description
+
+	# Stats column - spell properties
+	var stats: Array[String] = []
+
+	# School and level
+	var school_name = spell.school.capitalize()
+	var level_text = "Cantrip" if spell.level == 0 else "Level %d" % spell.level
+	stats.append("%s - %s" % [school_name, level_text])
+
+	# Mana cost
+	stats.append("Mana Cost: %d" % spell.mana_cost)
+
+	# Targeting
+	var targeting_mode = spell.get_targeting_mode()
+	var range_val = spell.get_range()
+	var target_text = targeting_mode.capitalize()
+	if range_val > 0:
+		target_text += " (Range: %d)" % range_val
+	stats.append("Target: %s" % target_text)
+
+	# Assign stats to lines
+	if stat_line_1:
+		stat_line_1.text = stats[0] if stats.size() > 0 else ""
+		stat_line_1.add_theme_color_override("font_color", SCHOOL_COLORS.get(spell.school, COLOR_NORMAL))
+	if stat_line_2:
+		stat_line_2.text = stats[1] if stats.size() > 1 else ""
+		stat_line_2.add_theme_color_override("font_color", COLOR_MANA)
+	if stat_line_3:
+		stat_line_3.text = stats[2] if stats.size() > 2 else ""
+		stat_line_3.add_theme_color_override("font_color", Color(0.7, 0.7, 0.7))
+
+	# Requirements column - check if player meets them
+	_update_requirements_display(spell)
+
+	# Footer
+	if footer_label:
+		footer_label.text = "[Esc/Shift+M] Close"
+
+func _update_requirements_display(spell) -> void:
+	if not player:
+		return
+
+	# INT requirement
+	var required_int = spell.get_min_intelligence()
+	var player_int = player.get_effective_attribute("INT")
+	var int_met = player_int >= required_int
+
+	if req_line_1:
+		req_line_1.text = "INT: %d required" % required_int
+		req_line_1.add_theme_color_override("font_color", COLOR_REQ_MET if int_met else COLOR_REQ_NOT_MET)
+
+	# Level requirement
+	var required_level = spell.get_min_level()
+	var player_level = player.level if "level" in player else 1
+	var level_met = player_level >= required_level
+
+	if req_line_2:
+		req_line_2.text = "Level: %d required" % required_level
+		req_line_2.add_theme_color_override("font_color", COLOR_REQ_MET if level_met else COLOR_REQ_NOT_MET)
+
+	# Castable status
+	if req_line_3:
+		var can_cast_result = SpellManager.can_cast(player, spell)
+		if can_cast_result.can_cast:
+			req_line_3.text = "Can cast"
+			req_line_3.add_theme_color_override("font_color", COLOR_REQ_MET)
+		else:
+			req_line_3.text = can_cast_result.reason
+			req_line_3.add_theme_color_override("font_color", COLOR_REQ_NOT_MET)
+
+func _navigate(direction: int) -> void:
+	if spells.is_empty():
+		return
+
+	selected_index = clampi(selected_index + direction, 0, spells.size() - 1)
+	_update_selection()

--- a/ui/spell_list_screen.tscn
+++ b/ui/spell_list_screen.tscn
@@ -1,0 +1,211 @@
+[gd_scene load_steps=4 format=3]
+
+[ext_resource type="Script" path="res://ui/spell_list_screen.gd" id="1_spell_list"]
+[ext_resource type="Theme" uid="uid://c7q6510one1wh" path="res://ui/themes/Underkingdom.tres" id="2_theme"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_panel"]
+bg_color = Color(0.08, 0.08, 0.12, 0.98)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.3, 0.5, 0.8, 1)
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4
+
+[node name="SpellListScreen" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("2_theme")
+script = ExtResource("1_spell_list")
+
+[node name="Dimmer" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0, 0, 0, 0.7)
+
+[node name="Panel" type="Panel" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -300.0
+offset_top = -280.0
+offset_right = 300.0
+offset_bottom = 280.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("2_theme")
+theme_override_styles/panel = SubResource("StyleBoxFlat_panel")
+
+[node name="MarginContainer" type="MarginContainer" parent="Panel"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 16
+theme_override_constants/margin_top = 12
+theme_override_constants/margin_right = 16
+theme_override_constants/margin_bottom = 12
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Panel/MarginContainer"]
+layout_mode = 2
+theme_override_constants/separation = 8
+
+[node name="TitleLabel" type="Label" parent="Panel/MarginContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.4, 0.7, 1, 1)
+theme_override_font_sizes/font_size = 20
+text = "* SPELLBOOK *"
+horizontal_alignment = 1
+
+[node name="HeaderPanel" type="HBoxContainer" parent="Panel/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="ManaLabel" type="Label" parent="Panel/MarginContainer/VBoxContainer/HeaderPanel"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_colors/font_color = Color(0.3, 0.6, 1, 1)
+theme_override_font_sizes/font_size = 14
+text = "Mana: 50 / 80"
+horizontal_alignment = 1
+
+[node name="HSeparator" type="HSeparator" parent="Panel/MarginContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_constants/separation = 4
+
+[node name="ContentContainer" type="VBoxContainer" parent="Panel/MarginContainer/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+theme_override_constants/separation = 8
+
+[node name="SpellListPanel" type="VBoxContainer" parent="Panel/MarginContainer/VBoxContainer/ContentContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+theme_override_constants/separation = 2
+
+[node name="SpellListTitle" type="Label" parent="Panel/MarginContainer/VBoxContainer/ContentContainer/SpellListPanel"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.6, 0.7, 0.9, 1)
+theme_override_font_sizes/font_size = 15
+text = "== KNOWN SPELLS =="
+horizontal_alignment = 1
+
+[node name="ScrollContainer" type="ScrollContainer" parent="Panel/MarginContainer/VBoxContainer/ContentContainer/SpellListPanel"]
+layout_mode = 2
+size_flags_vertical = 3
+horizontal_scroll_mode = 0
+
+[node name="SpellList" type="VBoxContainer" parent="Panel/MarginContainer/VBoxContainer/ContentContainer/SpellListPanel/ScrollContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/separation = 1
+
+[node name="HSeparator2" type="HSeparator" parent="Panel/MarginContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_constants/separation = 4
+
+[node name="DetailPanel" type="PanelContainer" parent="Panel/MarginContainer/VBoxContainer"]
+custom_minimum_size = Vector2(0, 120)
+layout_mode = 2
+size_flags_vertical = 0
+
+[node name="DetailVBox" type="VBoxContainer" parent="Panel/MarginContainer/VBoxContainer/DetailPanel"]
+layout_mode = 2
+theme_override_constants/separation = 4
+
+[node name="DetailColumns" type="HBoxContainer" parent="Panel/MarginContainer/VBoxContainer/DetailPanel/DetailVBox"]
+layout_mode = 2
+size_flags_vertical = 3
+theme_override_constants/separation = 12
+
+[node name="NameColumn" type="VBoxContainer" parent="Panel/MarginContainer/VBoxContainer/DetailPanel/DetailVBox/DetailColumns"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 1.2
+theme_override_constants/separation = 0
+
+[node name="SpellName" type="Label" parent="Panel/MarginContainer/VBoxContainer/DetailPanel/DetailVBox/DetailColumns/NameColumn"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.9, 0.9, 0.7, 1)
+theme_override_font_sizes/font_size = 14
+text = "Spell Name"
+
+[node name="SpellDesc" type="Label" parent="Panel/MarginContainer/VBoxContainer/DetailPanel/DetailVBox/DetailColumns/NameColumn"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.6, 0.6, 0.6, 1)
+theme_override_font_sizes/font_size = 12
+text = "Spell description goes here"
+autowrap_mode = 2
+
+[node name="StatsColumn" type="VBoxContainer" parent="Panel/MarginContainer/VBoxContainer/DetailPanel/DetailVBox/DetailColumns"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/separation = 0
+
+[node name="StatLine1" type="Label" parent="Panel/MarginContainer/VBoxContainer/DetailPanel/DetailVBox/DetailColumns/StatsColumn"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.7, 0.9, 0.7, 1)
+theme_override_font_sizes/font_size = 13
+
+[node name="StatLine2" type="Label" parent="Panel/MarginContainer/VBoxContainer/DetailPanel/DetailVBox/DetailColumns/StatsColumn"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.3, 0.6, 1, 1)
+theme_override_font_sizes/font_size = 13
+
+[node name="StatLine3" type="Label" parent="Panel/MarginContainer/VBoxContainer/DetailPanel/DetailVBox/DetailColumns/StatsColumn"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.7, 0.7, 0.7, 1)
+theme_override_font_sizes/font_size = 13
+
+[node name="ReqColumn" type="VBoxContainer" parent="Panel/MarginContainer/VBoxContainer/DetailPanel/DetailVBox/DetailColumns"]
+layout_mode = 2
+size_flags_horizontal = 0
+theme_override_constants/separation = 0
+
+[node name="ReqLine1" type="Label" parent="Panel/MarginContainer/VBoxContainer/DetailPanel/DetailVBox/DetailColumns/ReqColumn"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.5, 1, 0.5, 1)
+theme_override_font_sizes/font_size = 13
+horizontal_alignment = 2
+
+[node name="ReqLine2" type="Label" parent="Panel/MarginContainer/VBoxContainer/DetailPanel/DetailVBox/DetailColumns/ReqColumn"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.5, 1, 0.5, 1)
+theme_override_font_sizes/font_size = 13
+horizontal_alignment = 2
+
+[node name="ReqLine3" type="Label" parent="Panel/MarginContainer/VBoxContainer/DetailPanel/DetailVBox/DetailColumns/ReqColumn"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.5, 1, 0.5, 1)
+theme_override_font_sizes/font_size = 13
+horizontal_alignment = 2
+
+[node name="FooterRow" type="HBoxContainer" parent="Panel/MarginContainer/VBoxContainer/DetailPanel/DetailVBox"]
+layout_mode = 2
+size_flags_vertical = 8
+theme_override_constants/separation = 16
+
+[node name="Spacer" type="Control" parent="Panel/MarginContainer/VBoxContainer/DetailPanel/DetailVBox/FooterRow"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="FooterLabel" type="Label" parent="Panel/MarginContainer/VBoxContainer/DetailPanel/DetailVBox/FooterRow"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.5, 0.6, 0.7, 1)
+theme_override_font_sizes/font_size = 13
+text = "[Esc/Shift+M] Close"


### PR DESCRIPTION
Add spellbook item and spell learning mechanics:

Spellbook System:
- Add spellbook.json item with "spellbook" flag
- Add has_item_with_flag() to inventory system
- Player must have spellbook to learn/access spells

Spell Learning:
- Add known_spells: Array[String] to Player
- Add teaches_spell property to Item class
- Create spell tomes that teach spells when read
- Implement _use_spell_tome() with requirements checking
- Spell tomes consumed on successful learning

EventBus Signals:
- Add spell_learned(spell_id) signal
- Add spell_cast(caster, spell, targets, result) signal

Spell List UI:
- Create spell_list_screen.gd/tscn
- Show known spells with name, school, level, mana cost
- Detail panel shows requirements and castability
- Open with Shift+M keybinding

Save/Load:
- Persist known_spells in save files
- Backwards compatible (uses .has() check)

Documentation:
- Update magic-system.md with Phase 03 details
- Update input-handler.md with Shift+M keybinding
- Update help_screen.gd with new keybinding

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>