### PR TITLE
feat(magic): Implement Phase 04 - Spell Casting System

### DIFF
--- a/autoload/spell_manager.gd
+++ b/autoload/spell_manager.gd
@@ -228,3 +228,21 @@ func calculate_spell_duration(spell, caster) -> int:
 	var total_duration = base_duration + (scaling * level_bonus)
 
 	return total_duration
+
+
+## Calculate spell healing for a caster
+## Returns base healing + scaling bonus
+func calculate_spell_healing(spell, caster) -> int:
+	if not spell.is_heal_spell():
+		return 0
+
+	var heal_info = spell.get_heal()
+	var base_heal = heal_info.get("base", 0)
+	var scaling = heal_info.get("scaling", 0)
+	var caster_level = _get_caster_level(caster)
+
+	# Healing scales with caster level above spell's required level
+	var level_bonus = max(0, caster_level - spell.get_min_level())
+	var total_heal = base_heal + (scaling * level_bonus)
+
+	return total_heal

--- a/data/spells/conjuration/heal.json
+++ b/data/spells/conjuration/heal.json
@@ -1,7 +1,7 @@
 {
   "id": "heal",
   "name": "Heal",
-  "description": "Restore health to yourself or a touched ally.",
+  "description": "Restore health to yourself.",
   "school": "conjuration",
   "level": 1,
   "mana_cost": 8,
@@ -10,8 +10,7 @@
     "intelligence": 8
   },
   "targeting": {
-    "mode": "touch",
-    "range": 1
+    "mode": "self"
   },
   "effects": {
     "heal": {

--- a/docs/systems/input-handler.md
+++ b/docs/systems/input-handler.md
@@ -82,6 +82,7 @@ var current_target: Entity = null
 | B | Toggle build mode |
 | M | Toggle world map |
 | Shift+M | Toggle spellbook |
+| K | Open spell casting (alias for Shift+M) |
 | P | Character sheet |
 | F1 / ? | Help screen |
 | L | Look mode |
@@ -151,6 +152,18 @@ When _awaiting_harvest_direction:
 Arrow/WASD: Harvest in direction
 Escape: Cancel harvest
 ```
+
+### Spell Targeting Mode
+
+When spell_targeting_active (casting ranged spell):
+```gdscript
+Tab/→/D: Cycle next target
+←/A: Cycle previous target
+Enter/Space/R/F: Cast spell on target
+Escape: Cancel spell targeting
+```
+
+Spell targeting is similar to ranged weapon targeting but casts the pending spell instead of firing a weapon.
 
 ## Wait Action
 

--- a/scenes/game.gd
+++ b/scenes/game.gd
@@ -37,6 +37,10 @@ var rest_menu: Control = null
 var spell_list_screen: Control = null
 var auto_pickup_enabled: bool = true  # Toggle for automatic item pickup
 
+# Spell casting state
+var pending_spell_id: String = ""  # Spell ID waiting for target selection
+var spell_targeting_active: bool = false
+
 # Rest system state
 var is_resting: bool = false
 var rest_turns_remaining: int = 0
@@ -72,6 +76,7 @@ const NpcMenuScreenScene = preload("res://ui/npc_menu_screen.tscn")
 const PauseMenuScene = preload("res://ui/pause_menu.tscn")
 const DeathScreenScene = preload("res://ui/death_screen.tscn")
 const SpellListScreenScene = preload("res://ui/spell_list_screen.tscn")
+const SpellCastingSystemClass = preload("res://systems/spell_casting_system.gd")
 
 func _ready() -> void:
 	# Get renderer reference
@@ -404,6 +409,8 @@ func _setup_spell_list_screen() -> void:
 		hud.add_child(spell_list_screen)
 		if spell_list_screen.has_signal("closed"):
 			spell_list_screen.closed.connect(_on_spell_list_closed)
+		if spell_list_screen.has_signal("spell_cast_requested"):
+			spell_list_screen.spell_cast_requested.connect(_on_spell_cast_requested)
 		print("[Game] Spell list screen scene instantiated and added to HUD")
 	else:
 		print("[Game] ERROR: Could not load spell_list_screen.tscn scene")
@@ -1927,6 +1934,105 @@ func _on_world_map_closed() -> void:
 ## Called when spell list is closed
 func _on_spell_list_closed() -> void:
 	input_handler.ui_blocking_input = false
+
+## Called when player requests to cast a spell from the spell list
+func _on_spell_cast_requested(spell_id: String) -> void:
+	input_handler.ui_blocking_input = false
+
+	if not player or not spell_id:
+		return
+
+	var spell = SpellManager.get_spell(spell_id)
+	if not spell:
+		_add_message("Unknown spell.", Color(1.0, 0.5, 0.5))
+		return
+
+	var targeting_mode = spell.get_targeting_mode()
+
+	if targeting_mode == "self":
+		# Self-targeting spells cast immediately
+		_cast_spell_on_target(spell, player)
+	elif targeting_mode in ["ranged", "touch"]:
+		# Ranged spells need target selection
+		var valid_targets = SpellCastingSystemClass.get_valid_spell_targets(player, spell)
+		if valid_targets.is_empty():
+			_add_message("No valid targets in range.", Color(1.0, 0.8, 0.3))
+			return
+
+		# Enter spell targeting mode
+		pending_spell_id = spell_id
+		spell_targeting_active = true
+		input_handler.ui_blocking_input = true
+
+		# Use the targeting system
+		if input_handler.targeting_system:
+			# Start targeting with spell instead of weapon
+			_start_spell_targeting(spell, valid_targets)
+		else:
+			_add_message("Targeting system not available.", Color(1.0, 0.5, 0.5))
+			_cancel_spell_targeting()
+	else:
+		_add_message("Unsupported targeting mode: %s" % targeting_mode, Color(1.0, 0.5, 0.5))
+
+
+## Start spell targeting mode
+func _start_spell_targeting(spell, targets: Array) -> void:
+	if targets.is_empty():
+		return
+
+	# Set up targeting system for spell
+	var ts = input_handler.targeting_system
+	ts.is_targeting = true
+	ts.valid_targets = targets
+	ts.target_index = 0
+	ts.current_target = targets[0]
+	ts.attacker = player
+	ts.weapon = null  # No weapon for spell targeting
+
+	# Store the spell for when targeting confirms
+	pending_spell_id = spell.id
+
+	ts.targeting_started.emit()
+	ts.target_changed.emit(ts.current_target)
+
+	_add_message("Select target for %s (Tab to cycle, Enter to cast, Esc to cancel)" % spell.name, Color(0.5, 0.8, 1.0))
+
+
+## Cast a spell on a specific target
+func _cast_spell_on_target(spell, target) -> void:
+	var result = SpellCastingSystemClass.cast_spell(player, spell, target)
+
+	if result.success:
+		_add_message(result.message, Color(0.5, 0.8, 1.0))
+		TurnManager.advance_turn()
+	elif result.failed:
+		_add_message(result.message, Color(1.0, 0.8, 0.3))
+		TurnManager.advance_turn()  # Still costs a turn
+	else:
+		_add_message(result.message, Color(1.0, 0.5, 0.5))
+
+	# Update HUD to show mana change
+	_update_hud()
+	_render_all_entities()
+
+
+## Cast the pending spell on a target (called from input_handler during spell targeting)
+func cast_pending_spell_on_target(target) -> void:
+	if pending_spell_id.is_empty():
+		return
+	var spell = SpellManager.get_spell(pending_spell_id)
+	if spell and target:
+		_cast_spell_on_target(spell, target)
+
+
+## Cancel spell targeting mode
+func _cancel_spell_targeting() -> void:
+	pending_spell_id = ""
+	spell_targeting_active = false
+	input_handler.ui_blocking_input = false
+
+	if input_handler.targeting_system:
+		input_handler.targeting_system.cancel()
 
 ## Toggle fast travel screen (called from input handler)
 func toggle_fast_travel() -> void:

--- a/ui/help_screen.gd
+++ b/ui/help_screen.gd
@@ -100,7 +100,7 @@ func _build_help_content() -> void:
 	_add_section_header("== MENUS & UI ==")
 	_add_keybind("P", "Character sheet")
 	_add_keybind("M", "World map")
-	_add_keybind("Shift+M", "Spellbook (view known spells)")
+	_add_keybind("Shift+M / K", "Spellbook (view & cast spells)")
 	_add_keybind("Z", "Fast travel to visited locations")
 	_add_keybind("? or F1", "This help screen")
 	_add_keybind("ESC", "Pause menu / close UI")


### PR DESCRIPTION
Add SpellCastingSystem for casting spells with targeting, effects, and failure:
- cast_spell() handles self/ranged/touch targeting modes
- Spell failure chance based on caster level vs spell level
- Failure types: fizzle (70%), backfire (25%), wild magic (5%)
- INT bonus reduces failure chance
- Cantrips (level 0) never fail

Integration:
- Spell list screen now casts spells (Enter/C)
- Ranged spells use existing TargetingSystem
- Self-targeting spells cast immediately
- K keybinding added as alias for Shift+M (spellbook)
- spell_targeting_active flag differentiates spell vs weapon targeting

Effects:
- Damage/healing scale with caster level
- Buff effects apply with duration scaling
- Mana consumed on cast (including failures)
- Cast messages logged to game log

Documentation updated for spell casting mechanics.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>