### PR TITLE
feat(magic): Implement Phase 05 - Ranged Spell Targeting

### DIFF
--- a/docs/systems/magic-system.md
+++ b/docs/systems/magic-system.md
@@ -14,6 +14,7 @@ The magic system consists of two main components:
 - **Phase 02** (Spell Data & Manager) - Implemented
 - **Phase 03** (Spellbook & Spell Learning) - Implemented
 - **Phase 04** (Spell Casting) - Implemented
+- **Phase 05** (Ranged Spell Targeting) - Implemented
 
 Remaining phases are planned.
 


### PR DESCRIPTION
Integrate spell casting with TargetingSystem for proper ranged targeting:

TargetingSystem enhancements:
- Add is_spell_targeting and targeting_spell properties
- Add start_spell_targeting(caster, spell) method
- Add confirm_spell_target() method that casts the spell
- Update get_status_text() to show "CASTING: [Spell]" for spells
- Update get_help_text() with spell-specific controls

game.gd cleanup:
- Remove redundant spell_targeting_active and pending_spell_id
- Simplify _on_spell_cast_requested() to use targeting_system
- Remove cast_pending_spell_on_target() and _cancel_spell_targeting()

input_handler.gd:
- Use targeting_system.is_spell_targeting instead of game flags
- Add _process_spell_result() for spell cast feedback
- Clean up targeting confirmation to use targeting_system methods

Documentation updated for spell targeting in TargetingSystem.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>