### PR TITLE
feat: Add creature type system and elemental resistances

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -412,6 +412,7 @@ res://
 - Features: `data/features/` → FeatureManager
 - Hazards: `data/hazards/` → HazardManager
 - Spells: `data/spells/` → SpellManager
+- Creature Types: `data/creature_types/` → CreatureTypeManager
 
 **JSON file template:**
 ```json
@@ -499,6 +500,7 @@ The `*` prefix makes the autoload a singleton that's accessible globally by name
 - MapManager, ChunkManager, BiomeManager, DungeonManager, EntityManager
 - ItemManager, RecipeManager, StructureManager, SaveManager, VariantManager
 - WeatherManager, LootTableManager, SpellManager, IdentificationManager, RitualManager
+- SkillManager, CreatureTypeManager
 
 **Common Mistake:**
 ```gdscript
@@ -733,6 +735,7 @@ docs/
 | `resource-spawner.md` | `systems/resource_spawner.gd` | Resource placement |
 | `recipe-manager.md` | `autoload/recipe_manager.gd` | Recipe loading |
 | `spell-manager.md` | `autoload/spell_manager.gd` | Spell loading and requirements |
+| `creature-type-manager.md` | `autoload/creature_type_manager.gd` | Creature type definitions and resistances |
 | `magic-system.md` | (overview) | Magic system overview |
 
 ### Data Documentation Files

--- a/autoload/creature_type_manager.gd
+++ b/autoload/creature_type_manager.gd
@@ -1,0 +1,176 @@
+extends Node
+class_name CreatureTypeManagerClass
+## Manages creature type definitions and type-level resistances
+##
+## Creature types are loaded from JSON files in data/creature_types/
+## Provides type-level and subtype-level resistances that can be overridden
+## by per-creature definitions in enemy JSON files.
+##
+## Resistance precedence (highest to lowest):
+## 1. Per-creature elemental_resistances in enemy JSON
+## 2. Subtype resistances (e.g., fire elemental fire immunity)
+## 3. Type-level base_resistances (e.g., undead poison immunity)
+
+const CREATURE_TYPE_DATA_PATH = "res://data/creature_types"
+
+## Creature type definitions loaded from JSON
+## Key: creature_type_id (e.g., "undead"), Value: full definition dictionary
+var creature_type_definitions: Dictionary = {}
+
+
+func _ready() -> void:
+	_load_creature_type_definitions()
+	print("[CreatureTypeManager] Initialized with %d creature type definitions" % creature_type_definitions.size())
+
+
+## Load all creature type definitions from JSON files
+func _load_creature_type_definitions() -> void:
+	var dir = DirAccess.open(CREATURE_TYPE_DATA_PATH)
+	if not dir:
+		push_warning("[CreatureTypeManager] No creature type data directory found: " + CREATURE_TYPE_DATA_PATH)
+		return
+
+	dir.list_dir_begin()
+	var file_name = dir.get_next()
+
+	while file_name != "":
+		if file_name.ends_with(".json"):
+			var file_path = CREATURE_TYPE_DATA_PATH + "/" + file_name
+			_load_creature_type_file(file_path)
+		file_name = dir.get_next()
+
+	dir.list_dir_end()
+
+
+## Load a single creature type definition from JSON
+func _load_creature_type_file(file_path: String) -> void:
+	var file = FileAccess.open(file_path, FileAccess.READ)
+	if not file:
+		push_error("[CreatureTypeManager] Failed to open file: " + file_path)
+		return
+
+	var json = JSON.new()
+	var error = json.parse(file.get_as_text())
+
+	if error != OK:
+		push_error("[CreatureTypeManager] JSON parse error in %s: %s" % [file_path, json.get_error_message()])
+		return
+
+	var data: Dictionary = json.data
+	if not data.has("id"):
+		push_error("[CreatureTypeManager] Missing 'id' field in: " + file_path)
+		return
+
+	creature_type_definitions[data.id] = data
+
+
+## Get a creature type definition by ID
+## Returns empty dictionary if not found
+func get_creature_type(creature_type_id: String) -> Dictionary:
+	return creature_type_definitions.get(creature_type_id, {})
+
+
+## Get all creature type IDs
+func get_all_creature_type_ids() -> Array[String]:
+	var result: Array[String] = []
+	for type_id in creature_type_definitions:
+		result.append(type_id)
+	return result
+
+
+## Calculate merged resistances for a creature
+## Applies resistances in order: type base -> subtype -> per-creature
+## Higher priority values override lower priority values for the same element
+##
+## Parameters:
+##   creature_type: Base type (e.g., "elemental", "undead")
+##   element_subtype: Optional subtype (e.g., "fire", "ice")
+##   creature_resistances: Per-creature overrides from enemy JSON
+##
+## Returns: Dictionary of merged resistances {element: value}
+func get_merged_resistances(creature_type: String, element_subtype: String = "", creature_resistances: Dictionary = {}) -> Dictionary:
+	var result: Dictionary = {}
+
+	# Layer 1: Type-level base resistances (lowest priority)
+	var type_def = get_creature_type(creature_type)
+	if not type_def.is_empty():
+		var base_res = type_def.get("base_resistances", {})
+		for element in base_res:
+			result[element] = base_res[element]
+
+	# Layer 2: Subtype resistances (medium priority)
+	if element_subtype != "" and not type_def.is_empty():
+		var subtypes = type_def.get("subtypes", {})
+		if subtypes.has(element_subtype):
+			var subtype_res = subtypes[element_subtype].get("resistances", {})
+			for element in subtype_res:
+				result[element] = subtype_res[element]
+
+	# Layer 3: Per-creature resistances (highest priority)
+	for element in creature_resistances:
+		result[element] = creature_resistances[element]
+
+	return result
+
+
+## Check if a creature type has a special rule
+## Special rules include: heals_from_necrotic, vulnerable_to_radiant, immune_to_poison, etc.
+func has_special_rule(creature_type: String, rule_name: String) -> bool:
+	var type_def = get_creature_type(creature_type)
+	if type_def.is_empty():
+		return false
+	var rules = type_def.get("special_rules", {})
+	return rules.get(rule_name, false)
+
+
+## Get a special rule value (for rules with numeric values like radiant_vulnerability_bonus)
+func get_special_rule_value(creature_type: String, rule_name: String, default_value = null):
+	var type_def = get_creature_type(creature_type)
+	if type_def.is_empty():
+		return default_value
+	return type_def.get(rule_name, default_value)
+
+
+## Get display name for a creature type
+func get_type_display_name(creature_type: String) -> String:
+	var type_def = get_creature_type(creature_type)
+	return type_def.get("name", creature_type.capitalize())
+
+
+## Get display name for a subtype
+func get_subtype_display_name(creature_type: String, element_subtype: String) -> String:
+	var type_def = get_creature_type(creature_type)
+	if type_def.is_empty():
+		return element_subtype.capitalize()
+	var subtypes = type_def.get("subtypes", {})
+	if subtypes.has(element_subtype):
+		return subtypes[element_subtype].get("name", element_subtype.capitalize())
+	return element_subtype.capitalize()
+
+
+## Get abbreviated creature type for display (3-4 chars)
+func get_type_abbreviation(creature_type: String) -> String:
+	match creature_type:
+		"humanoid": return "HUM"
+		"undead": return "UND"
+		"elemental": return "ELE"
+		"construct": return "CON"
+		"demon": return "DEM"
+		"ooze": return "OOZ"
+		"beast": return "BST"
+		"monstrosity": return "MON"
+		"aberration": return "ABR"
+		"animal": return "ANI"
+		_: return creature_type.substr(0, 3).to_upper()
+
+
+## Get description for a creature type
+func get_type_description(creature_type: String) -> String:
+	var type_def = get_creature_type(creature_type)
+	return type_def.get("description", "")
+
+
+## Get ascii color for a creature type (for UI display)
+func get_type_color(creature_type: String) -> String:
+	var type_def = get_creature_type(creature_type)
+	return type_def.get("ascii_color", "#FFFFFF")

--- a/autoload/creature_type_manager.gd.uid
+++ b/autoload/creature_type_manager.gd.uid
@@ -1,0 +1,1 @@
+uid://bvsd0lu42iut8

--- a/data/creature_types/aberration.json
+++ b/data/creature_types/aberration.json
@@ -1,0 +1,11 @@
+{
+  "id": "aberration",
+  "name": "Aberration",
+  "description": "Utterly alien beings from beyond normal reality",
+  "ascii_color": "#8B008B",
+  "base_resistances": {},
+  "special_rules": {
+    "immune_to_mind_control": true
+  },
+  "subtypes": {}
+}

--- a/data/creature_types/beast.json
+++ b/data/creature_types/beast.json
@@ -1,0 +1,11 @@
+{
+  "id": "beast",
+  "name": "Beast",
+  "description": "Natural animals and wildlife",
+  "ascii_color": "#8B4513",
+  "base_resistances": {},
+  "special_rules": {
+    "susceptible_to_animal_handling": true
+  },
+  "subtypes": {}
+}

--- a/data/creature_types/construct.json
+++ b/data/creature_types/construct.json
@@ -1,0 +1,15 @@
+{
+  "id": "construct",
+  "name": "Construct",
+  "description": "Artificially created beings animated by magic",
+  "ascii_color": "#9370DB",
+  "base_resistances": {
+    "poison": -100,
+    "necrotic": -50
+  },
+  "special_rules": {
+    "immune_to_poison": true,
+    "immune_to_mind_control": true
+  },
+  "subtypes": {}
+}

--- a/data/creature_types/demon.json
+++ b/data/creature_types/demon.json
@@ -1,0 +1,15 @@
+{
+  "id": "demon",
+  "name": "Demon",
+  "description": "Fiendish beings from the lower planes",
+  "ascii_color": "#FF3333",
+  "base_resistances": {
+    "fire": -50,
+    "radiant": 50,
+    "necrotic": -25
+  },
+  "special_rules": {
+    "resistant_to_fire": true
+  },
+  "subtypes": {}
+}

--- a/data/creature_types/elemental.json
+++ b/data/creature_types/elemental.json
@@ -1,0 +1,42 @@
+{
+  "id": "elemental",
+  "name": "Elemental",
+  "description": "Beings of pure elemental energy from the elemental planes",
+  "ascii_color": "#00FFFF",
+  "base_resistances": {
+    "poison": -100
+  },
+  "special_rules": {
+    "immune_to_poison": true,
+    "immune_to_mind_control": true
+  },
+  "subtypes": {
+    "fire": {
+      "name": "Fire Elemental",
+      "resistances": {
+        "fire": -100,
+        "ice": 100
+      }
+    },
+    "ice": {
+      "name": "Ice Elemental",
+      "resistances": {
+        "ice": -100,
+        "fire": 100
+      }
+    },
+    "earth": {
+      "name": "Earth Elemental",
+      "resistances": {
+        "piercing": -50,
+        "bludgeoning": -25
+      }
+    },
+    "air": {
+      "name": "Air Elemental",
+      "resistances": {
+        "lightning": -25
+      }
+    }
+  }
+}

--- a/data/creature_types/humanoid.json
+++ b/data/creature_types/humanoid.json
@@ -1,0 +1,9 @@
+{
+  "id": "humanoid",
+  "name": "Humanoid",
+  "description": "Intelligent bipedal creatures",
+  "ascii_color": "#FFFFFF",
+  "base_resistances": {},
+  "special_rules": {},
+  "subtypes": {}
+}

--- a/data/creature_types/monstrosity.json
+++ b/data/creature_types/monstrosity.json
@@ -1,0 +1,9 @@
+{
+  "id": "monstrosity",
+  "name": "Monstrosity",
+  "description": "Unnatural creatures that are not classified elsewhere",
+  "ascii_color": "#800080",
+  "base_resistances": {},
+  "special_rules": {},
+  "subtypes": {}
+}

--- a/data/creature_types/ooze.json
+++ b/data/creature_types/ooze.json
@@ -1,0 +1,15 @@
+{
+  "id": "ooze",
+  "name": "Ooze",
+  "description": "Amorphous creatures that dissolve organic matter",
+  "ascii_color": "#32CD32",
+  "base_resistances": {
+    "slashing": -50,
+    "piercing": -50,
+    "acid": -100
+  },
+  "special_rules": {
+    "immune_to_mind_control": true
+  },
+  "subtypes": {}
+}

--- a/data/creature_types/undead.json
+++ b/data/creature_types/undead.json
@@ -1,0 +1,18 @@
+{
+  "id": "undead",
+  "name": "Undead",
+  "description": "Reanimated corpses or spirits bound to the mortal realm",
+  "ascii_color": "#708090",
+  "base_resistances": {
+    "poison": -100,
+    "necrotic": -100
+  },
+  "special_rules": {
+    "heals_from_necrotic": true,
+    "vulnerable_to_radiant": true,
+    "immune_to_poison": true,
+    "immune_to_mind_control": true
+  },
+  "radiant_vulnerability_bonus": 50,
+  "subtypes": {}
+}

--- a/data/enemies/aberrations/animated_armor.json
+++ b/data/enemies/aberrations/animated_armor.json
@@ -5,6 +5,7 @@
   "cr": 1,
   "ascii_char": "A",
   "ascii_color": "#708090",
+  "creature_type": "aberration",
   "stats": {
     "health": 33,
     "str": 14,
@@ -14,17 +15,30 @@
     "wis": 3,
     "cha": 1
   },
-  "yields": [
-    {"item_id": "iron_ore", "min_count": 2, "max_count": 4, "chance": 0.9},
-    {"item_id": "arcane_dust", "min_count": 1, "max_count": 1, "chance": 0.3}
-  ],
-  "behavior": "guardian",
   "base_damage": 6,
   "armor": 6,
+  "yields": [
+    {
+      "item_id": "iron_ore",
+      "min_count": 2,
+      "max_count": 4,
+      "chance": 0.9
+    },
+    {
+      "item_id": "arcane_dust",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.3
+    }
+  ],
+  "behavior": "guardian",
   "loot_table": "construct_common",
   "xp_value": 40,
   "spawn_biomes": [],
-  "spawn_dungeons": ["wizard_tower", "ancient_fort"],
+  "spawn_dungeons": [
+    "wizard_tower",
+    "ancient_fort"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 100,
   "min_spawn_level": 1,

--- a/data/enemies/aberrations/apprentice_mage.json
+++ b/data/enemies/aberrations/apprentice_mage.json
@@ -5,6 +5,7 @@
   "cr": 0.5,
   "ascii_char": "m",
   "ascii_color": "#9932CC",
+  "creature_type": "aberration",
   "stats": {
     "health": 15,
     "str": 8,
@@ -14,21 +15,33 @@
     "wis": 12,
     "cha": 10
   },
-  "yields": [
-    {"item_id": "spell_scroll", "min_count": 1, "max_count": 1, "chance": 0.4},
-    {"item_id": "arcane_dust", "min_count": 1, "max_count": 2, "chance": 0.7}
-  ],
-  "behavior": "aggressive",
   "base_damage": 4,
   "armor": 0,
-  "attack_type": "ranged",
-  "attack_range": 4,
+  "yields": [
+    {
+      "item_id": "spell_scroll",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.4
+    },
+    {
+      "item_id": "arcane_dust",
+      "min_count": 1,
+      "max_count": 2,
+      "chance": 0.7
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "magic_common",
   "xp_value": 25,
   "spawn_biomes": [],
-  "spawn_dungeons": ["wizard_tower"],
+  "spawn_dungeons": [
+    "wizard_tower"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 90,
   "min_spawn_level": 1,
-  "max_spawn_level": 10
+  "max_spawn_level": 10,
+  "attack_type": "ranged",
+  "attack_range": 4
 }

--- a/data/enemies/aberrations/arcane_eye.json
+++ b/data/enemies/aberrations/arcane_eye.json
@@ -5,6 +5,7 @@
   "cr": 2,
   "ascii_char": "e",
   "ascii_color": "#00CED1",
+  "creature_type": "aberration",
   "stats": {
     "health": 20,
     "str": 4,
@@ -14,21 +15,33 @@
     "wis": 16,
     "cha": 8
   },
-  "yields": [
-    {"item_id": "mana_crystal", "min_count": 1, "max_count": 2, "chance": 0.6},
-    {"item_id": "arcane_dust", "min_count": 1, "max_count": 3, "chance": 0.8}
-  ],
-  "behavior": "aggressive",
   "base_damage": 7,
   "armor": 1,
-  "attack_type": "ranged",
-  "attack_range": 5,
+  "yields": [
+    {
+      "item_id": "mana_crystal",
+      "min_count": 1,
+      "max_count": 2,
+      "chance": 0.6
+    },
+    {
+      "item_id": "arcane_dust",
+      "min_count": 1,
+      "max_count": 3,
+      "chance": 0.8
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "magic_common",
   "xp_value": 50,
   "spawn_biomes": [],
-  "spawn_dungeons": ["wizard_tower"],
+  "spawn_dungeons": [
+    "wizard_tower"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 100,
   "min_spawn_level": 3,
-  "max_spawn_level": 20
+  "max_spawn_level": 20,
+  "attack_type": "ranged",
+  "attack_range": 5
 }

--- a/data/enemies/aberrations/divine_guardian.json
+++ b/data/enemies/aberrations/divine_guardian.json
@@ -5,6 +5,7 @@
   "cr": 4,
   "ascii_char": "G",
   "ascii_color": "#FFD700",
+  "creature_type": "aberration",
   "stats": {
     "health": 50,
     "str": 16,
@@ -14,17 +15,29 @@
     "wis": 16,
     "cha": 14
   },
-  "yields": [
-    {"item_id": "divine_essence", "min_count": 1, "max_count": 2, "chance": 0.6},
-    {"item_id": "holy_symbol", "min_count": 1, "max_count": 1, "chance": 0.2}
-  ],
-  "behavior": "guardian",
   "base_damage": 10,
   "armor": 4,
+  "yields": [
+    {
+      "item_id": "divine_essence",
+      "min_count": 1,
+      "max_count": 2,
+      "chance": 0.6
+    },
+    {
+      "item_id": "holy_symbol",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.2
+    }
+  ],
+  "behavior": "guardian",
   "loot_table": "divine_rare",
   "xp_value": 100,
   "spawn_biomes": [],
-  "spawn_dungeons": ["temple_ruins"],
+  "spawn_dungeons": [
+    "temple_ruins"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 180,
   "min_spawn_level": 6,

--- a/data/enemies/aberrations/flying_sword.json
+++ b/data/enemies/aberrations/flying_sword.json
@@ -5,6 +5,7 @@
   "cr": 0.25,
   "ascii_char": "/",
   "ascii_color": "#C0C0C0",
+  "creature_type": "aberration",
   "stats": {
     "health": 17,
     "str": 12,
@@ -14,16 +15,23 @@
     "wis": 5,
     "cha": 1
   },
-  "yields": [
-    {"item_id": "iron_ore", "min_count": 1, "max_count": 2, "chance": 0.8}
-  ],
-  "behavior": "aggressive",
   "base_damage": 5,
   "armor": 3,
+  "yields": [
+    {
+      "item_id": "iron_ore",
+      "min_count": 1,
+      "max_count": 2,
+      "chance": 0.8
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "construct_common",
   "xp_value": 20,
   "spawn_biomes": [],
-  "spawn_dungeons": ["wizard_tower"],
+  "spawn_dungeons": [
+    "wizard_tower"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 80,
   "min_spawn_level": 1,

--- a/data/enemies/aberrations/homunculus.json
+++ b/data/enemies/aberrations/homunculus.json
@@ -5,6 +5,7 @@
   "cr": 0,
   "ascii_char": "h",
   "ascii_color": "#DEB887",
+  "creature_type": "aberration",
   "stats": {
     "health": 5,
     "str": 4,
@@ -14,16 +15,23 @@
     "wis": 10,
     "cha": 7
   },
-  "yields": [
-    {"item_id": "arcane_dust", "min_count": 1, "max_count": 1, "chance": 0.5}
-  ],
-  "behavior": "aggressive",
   "base_damage": 2,
   "armor": 0,
+  "yields": [
+    {
+      "item_id": "arcane_dust",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.5
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "magic_common",
   "xp_value": 10,
   "spawn_biomes": [],
-  "spawn_dungeons": ["wizard_tower"],
+  "spawn_dungeons": [
+    "wizard_tower"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 60,
   "min_spawn_level": 1,

--- a/data/enemies/aberrations/rogue_spell.json
+++ b/data/enemies/aberrations/rogue_spell.json
@@ -5,6 +5,7 @@
   "cr": 1,
   "ascii_char": "*",
   "ascii_color": "#00BFFF",
+  "creature_type": "aberration",
   "stats": {
     "health": 15,
     "str": 4,
@@ -14,17 +15,29 @@
     "wis": 12,
     "cha": 8
   },
-  "yields": [
-    {"item_id": "spell_fragment", "min_count": 1, "max_count": 2, "chance": 0.7},
-    {"item_id": "mana_crystal", "min_count": 1, "max_count": 1, "chance": 0.4}
-  ],
-  "behavior": "aggressive",
   "base_damage": 6,
   "armor": 0,
+  "yields": [
+    {
+      "item_id": "spell_fragment",
+      "min_count": 1,
+      "max_count": 2,
+      "chance": 0.7
+    },
+    {
+      "item_id": "mana_crystal",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.4
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "magic_common",
   "xp_value": 30,
   "spawn_biomes": [],
-  "spawn_dungeons": ["wizard_tower"],
+  "spawn_dungeons": [
+    "wizard_tower"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 90,
   "min_spawn_level": 1,

--- a/data/enemies/aberrations/summoned_demon.json
+++ b/data/enemies/aberrations/summoned_demon.json
@@ -5,6 +5,7 @@
   "cr": 4,
   "ascii_char": "D",
   "ascii_color": "#FF4500",
+  "creature_type": "aberration",
   "stats": {
     "health": 45,
     "str": 16,
@@ -14,17 +15,30 @@
     "wis": 10,
     "cha": 12
   },
-  "yields": [
-    {"item_id": "demon_essence", "min_count": 1, "max_count": 2, "chance": 0.6},
-    {"item_id": "infernal_shard", "min_count": 1, "max_count": 1, "chance": 0.3}
-  ],
-  "behavior": "aggressive",
   "base_damage": 10,
   "armor": 3,
+  "yields": [
+    {
+      "item_id": "demon_essence",
+      "min_count": 1,
+      "max_count": 2,
+      "chance": 0.6
+    },
+    {
+      "item_id": "infernal_shard",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.3
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "demon_common",
   "xp_value": 80,
   "spawn_biomes": [],
-  "spawn_dungeons": ["wizard_tower", "temple_ruins"],
+  "spawn_dungeons": [
+    "wizard_tower",
+    "temple_ruins"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 180,
   "min_spawn_level": 5,

--- a/data/enemies/aberrations/wizard.json
+++ b/data/enemies/aberrations/wizard.json
@@ -5,6 +5,7 @@
   "cr": 6,
   "ascii_char": "W",
   "ascii_color": "#8A2BE2",
+  "creature_type": "aberration",
   "stats": {
     "health": 35,
     "str": 8,
@@ -14,18 +15,35 @@
     "wis": 16,
     "cha": 14
   },
-  "yields": [
-    {"item_id": "spell_scroll", "min_count": 1, "max_count": 2, "chance": 0.7},
-    {"item_id": "wizard_staff", "min_count": 1, "max_count": 1, "chance": 0.3},
-    {"item_id": "magic_robe", "min_count": 1, "max_count": 1, "chance": 0.4}
-  ],
-  "behavior": "aggressive",
   "base_damage": 8,
   "armor": 1,
+  "yields": [
+    {
+      "item_id": "spell_scroll",
+      "min_count": 1,
+      "max_count": 2,
+      "chance": 0.7
+    },
+    {
+      "item_id": "wizard_staff",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.3
+    },
+    {
+      "item_id": "magic_robe",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.4
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "wizard_rare",
   "xp_value": 100,
   "spawn_biomes": [],
-  "spawn_dungeons": ["wizard_tower"],
+  "spawn_dungeons": [
+    "wizard_tower"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 200,
   "min_spawn_level": 10,

--- a/data/enemies/animals/deer.json
+++ b/data/enemies/animals/deer.json
@@ -5,6 +5,7 @@
   "cr": 0,
   "ascii_char": "d",
   "ascii_color": "#8B4513",
+  "creature_type": "beast",
   "stats": {
     "health": 10,
     "str": 8,
@@ -14,15 +15,28 @@
     "wis": 12,
     "cha": 6
   },
-  "yields": [
-    {"item_id": "raw_meat", "min_count": 2, "max_count": 3, "chance": 1.0},
-    {"item_id": "leather", "min_count": 1, "max_count": 2, "chance": 0.8}
-  ],
-  "behavior": "passive",
   "base_damage": 0,
   "armor": 0,
+  "yields": [
+    {
+      "item_id": "raw_meat",
+      "min_count": 2,
+      "max_count": 3,
+      "chance": 1.0
+    },
+    {
+      "item_id": "leather",
+      "min_count": 1,
+      "max_count": 2,
+      "chance": 0.8
+    }
+  ],
+  "behavior": "passive",
   "xp_value": 10,
-  "spawn_biomes": ["forest", "woodland"],
+  "spawn_biomes": [
+    "forest",
+    "woodland"
+  ],
   "spawn_dungeons": [],
   "spawn_density_overworld": 600,
   "spawn_density_dungeon": 0,

--- a/data/enemies/animals/hare.json
+++ b/data/enemies/animals/hare.json
@@ -5,6 +5,7 @@
   "cr": 0,
   "ascii_char": "r",
   "ascii_color": "#F5F5F5",
+  "creature_type": "beast",
   "stats": {
     "health": 4,
     "str": 2,
@@ -14,14 +15,22 @@
     "wis": 11,
     "cha": 4
   },
-  "yields": [
-    {"item_id": "raw_meat", "min_count": 1, "max_count": 1, "chance": 1.0}
-  ],
-  "behavior": "passive",
   "base_damage": 0,
   "armor": 0,
+  "yields": [
+    {
+      "item_id": "raw_meat",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 1.0
+    }
+  ],
+  "behavior": "passive",
   "xp_value": 5,
-  "spawn_biomes": ["snow", "tundra"],
+  "spawn_biomes": [
+    "snow",
+    "tundra"
+  ],
   "spawn_dungeons": [],
   "spawn_density_overworld": 400,
   "spawn_density_dungeon": 0,

--- a/data/enemies/animals/mountain_goat.json
+++ b/data/enemies/animals/mountain_goat.json
@@ -5,6 +5,7 @@
   "cr": 0,
   "ascii_char": "g",
   "ascii_color": "#D3D3D3",
+  "creature_type": "beast",
   "stats": {
     "health": 12,
     "str": 10,
@@ -14,15 +15,28 @@
     "wis": 10,
     "cha": 5
   },
-  "yields": [
-    {"item_id": "raw_meat", "min_count": 2, "max_count": 3, "chance": 1.0},
-    {"item_id": "leather", "min_count": 1, "max_count": 1, "chance": 0.6}
-  ],
-  "behavior": "passive",
   "base_damage": 1,
   "armor": 0,
+  "yields": [
+    {
+      "item_id": "raw_meat",
+      "min_count": 2,
+      "max_count": 3,
+      "chance": 1.0
+    },
+    {
+      "item_id": "leather",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.6
+    }
+  ],
+  "behavior": "passive",
   "xp_value": 8,
-  "spawn_biomes": ["mountains", "rocky_hills"],
+  "spawn_biomes": [
+    "mountains",
+    "rocky_hills"
+  ],
   "spawn_dungeons": [],
   "spawn_density_overworld": 700,
   "spawn_density_dungeon": 0,

--- a/data/enemies/animals/pheasant.json
+++ b/data/enemies/animals/pheasant.json
@@ -5,6 +5,7 @@
   "cr": 0,
   "ascii_char": "p",
   "ascii_color": "#CD853F",
+  "creature_type": "beast",
   "stats": {
     "health": 4,
     "str": 3,
@@ -14,15 +15,29 @@
     "wis": 9,
     "cha": 4
   },
-  "yields": [
-    {"item_id": "raw_meat", "min_count": 1, "max_count": 1, "chance": 1.0},
-    {"item_id": "feather", "min_count": 1, "max_count": 3, "chance": 0.6}
-  ],
-  "behavior": "passive",
   "base_damage": 0,
   "armor": 0,
+  "yields": [
+    {
+      "item_id": "raw_meat",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 1.0
+    },
+    {
+      "item_id": "feather",
+      "min_count": 1,
+      "max_count": 3,
+      "chance": 0.6
+    }
+  ],
+  "behavior": "passive",
   "xp_value": 5,
-  "spawn_biomes": ["grassland", "woodland", "marsh"],
+  "spawn_biomes": [
+    "grassland",
+    "woodland",
+    "marsh"
+  ],
   "spawn_dungeons": [],
   "spawn_density_overworld": 400,
   "spawn_density_dungeon": 0,

--- a/data/enemies/animals/rabbit.json
+++ b/data/enemies/animals/rabbit.json
@@ -5,6 +5,7 @@
   "cr": 0,
   "ascii_char": "r",
   "ascii_color": "#A0522D",
+  "creature_type": "beast",
   "stats": {
     "health": 3,
     "str": 2,
@@ -14,14 +15,23 @@
     "wis": 10,
     "cha": 4
   },
-  "yields": [
-    {"item_id": "raw_meat", "min_count": 1, "max_count": 1, "chance": 1.0}
-  ],
-  "behavior": "passive",
   "base_damage": 0,
   "armor": 0,
+  "yields": [
+    {
+      "item_id": "raw_meat",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 1.0
+    }
+  ],
+  "behavior": "passive",
   "xp_value": 5,
-  "spawn_biomes": ["forest", "woodland", "grassland"],
+  "spawn_biomes": [
+    "forest",
+    "woodland",
+    "grassland"
+  ],
   "spawn_dungeons": [],
   "spawn_density_overworld": 300,
   "spawn_density_dungeon": 0,

--- a/data/enemies/beasts/boar.json
+++ b/data/enemies/beasts/boar.json
@@ -5,6 +5,7 @@
   "cr": 0.25,
   "ascii_char": "b",
   "ascii_color": "#8B4513",
+  "creature_type": "beast",
   "stats": {
     "health": 11,
     "str": 13,
@@ -14,16 +15,30 @@
     "wis": 9,
     "cha": 5
   },
-  "yields": [
-    {"item_id": "raw_meat", "min_count": 2, "max_count": 4, "chance": 1.0},
-    {"item_id": "boar_tusk", "min_count": 1, "max_count": 2, "chance": 0.5}
-  ],
-  "behavior": "aggressive",
   "base_damage": 4,
   "armor": 1,
+  "yields": [
+    {
+      "item_id": "raw_meat",
+      "min_count": 2,
+      "max_count": 4,
+      "chance": 1.0
+    },
+    {
+      "item_id": "boar_tusk",
+      "min_count": 1,
+      "max_count": 2,
+      "chance": 0.5
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "beast_common",
   "xp_value": 15,
-  "spawn_biomes": ["woodland", "forest", "grassland"],
+  "spawn_biomes": [
+    "woodland",
+    "forest",
+    "grassland"
+  ],
   "spawn_dungeons": [],
   "spawn_density_overworld": 500,
   "spawn_density_dungeon": 0,

--- a/data/enemies/beasts/brown_bear.json
+++ b/data/enemies/beasts/brown_bear.json
@@ -5,6 +5,7 @@
   "cr": 1,
   "ascii_char": "B",
   "ascii_color": "#8B4513",
+  "creature_type": "beast",
   "stats": {
     "health": 34,
     "str": 19,
@@ -14,16 +15,30 @@
     "wis": 13,
     "cha": 7
   },
-  "yields": [
-    {"item_id": "bear_pelt", "min_count": 1, "max_count": 1, "chance": 0.8},
-    {"item_id": "raw_meat", "min_count": 3, "max_count": 5, "chance": 1.0}
-  ],
-  "behavior": "aggressive",
   "base_damage": 9,
   "armor": 2,
+  "yields": [
+    {
+      "item_id": "bear_pelt",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.8
+    },
+    {
+      "item_id": "raw_meat",
+      "min_count": 3,
+      "max_count": 5,
+      "chance": 1.0
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "beast_common",
   "xp_value": 50,
-  "spawn_biomes": ["woodland", "forest", "mountains"],
+  "spawn_biomes": [
+    "woodland",
+    "forest",
+    "mountains"
+  ],
   "spawn_dungeons": [],
   "spawn_density_overworld": 200,
   "spawn_density_dungeon": 0,

--- a/data/enemies/beasts/cave_bat.json
+++ b/data/enemies/beasts/cave_bat.json
@@ -5,6 +5,7 @@
   "cr": 0,
   "ascii_char": "B",
   "ascii_color": "#4A4A4A",
+  "creature_type": "beast",
   "stats": {
     "health": 6,
     "str": 4,
@@ -14,16 +15,25 @@
     "wis": 12,
     "cha": 4
   },
-  "yields": [
-    {"item_id": "bat_wing", "min_count": 1, "max_count": 2, "chance": 0.6}
-  ],
-  "behavior": "aggressive",
   "base_damage": 2,
   "armor": 0,
+  "yields": [
+    {
+      "item_id": "bat_wing",
+      "min_count": 1,
+      "max_count": 2,
+      "chance": 0.6
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "bat_common",
   "xp_value": 5,
   "spawn_biomes": [],
-  "spawn_dungeons": ["natural_cave", "burial_barrow", "abandoned_mine"],
+  "spawn_dungeons": [
+    "natural_cave",
+    "burial_barrow",
+    "abandoned_mine"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 60,
   "min_spawn_level": 1,

--- a/data/enemies/beasts/cave_bear.json
+++ b/data/enemies/beasts/cave_bear.json
@@ -5,6 +5,7 @@
   "cr": 2,
   "ascii_char": "U",
   "ascii_color": "#8B4513",
+  "creature_type": "beast",
   "stats": {
     "health": 45,
     "str": 18,
@@ -14,17 +15,29 @@
     "wis": 12,
     "cha": 6
   },
-  "yields": [
-    {"item_id": "bear_pelt", "min_count": 1, "max_count": 1, "chance": 0.8},
-    {"item_id": "raw_meat", "min_count": 2, "max_count": 4, "chance": 1.0}
-  ],
-  "behavior": "aggressive",
   "base_damage": 10,
   "armor": 2,
+  "yields": [
+    {
+      "item_id": "bear_pelt",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.8
+    },
+    {
+      "item_id": "raw_meat",
+      "min_count": 2,
+      "max_count": 4,
+      "chance": 1.0
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "beast_rare",
   "xp_value": 60,
   "spawn_biomes": [],
-  "spawn_dungeons": ["natural_cave"],
+  "spawn_dungeons": [
+    "natural_cave"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 150,
   "min_spawn_level": 15,

--- a/data/enemies/beasts/crocodile.json
+++ b/data/enemies/beasts/crocodile.json
@@ -5,6 +5,7 @@
   "cr": 0.5,
   "ascii_char": "C",
   "ascii_color": "#2F4F4F",
+  "creature_type": "beast",
   "stats": {
     "health": 35,
     "str": 16,
@@ -14,17 +15,32 @@
     "wis": 10,
     "cha": 4
   },
-  "yields": [
-    {"item_id": "crocodile_hide", "min_count": 1, "max_count": 1, "chance": 0.7},
-    {"item_id": "raw_meat", "min_count": 2, "max_count": 4, "chance": 0.9}
-  ],
-  "behavior": "aggressive",
   "base_damage": 8,
   "armor": 3,
+  "yields": [
+    {
+      "item_id": "crocodile_hide",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.7
+    },
+    {
+      "item_id": "raw_meat",
+      "min_count": 2,
+      "max_count": 4,
+      "chance": 0.9
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "beast_common",
   "xp_value": 45,
-  "spawn_biomes": ["swamp", "marsh"],
-  "spawn_dungeons": ["sewers"],
+  "spawn_biomes": [
+    "swamp",
+    "marsh"
+  ],
+  "spawn_dungeons": [
+    "sewers"
+  ],
   "spawn_density_overworld": 200,
   "spawn_density_dungeon": 140,
   "min_spawn_level": 5,

--- a/data/enemies/beasts/dire_wolf.json
+++ b/data/enemies/beasts/dire_wolf.json
@@ -5,6 +5,7 @@
   "cr": 1,
   "ascii_char": "W",
   "ascii_color": "#696969",
+  "creature_type": "beast",
   "stats": {
     "health": 37,
     "str": 17,
@@ -14,22 +15,39 @@
     "wis": 12,
     "cha": 7
   },
-  "yields": [
-    {"item_id": "wolf_pelt", "min_count": 1, "max_count": 1, "chance": 0.9},
-    {"item_id": "raw_meat", "min_count": 2, "max_count": 4, "chance": 1.0}
-  ],
-  "behavior": "pack",
   "base_damage": 7,
   "armor": 1,
-  "feared_components": ["fire"],
-  "fear_distance": 5,
+  "yields": [
+    {
+      "item_id": "wolf_pelt",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.9
+    },
+    {
+      "item_id": "raw_meat",
+      "min_count": 2,
+      "max_count": 4,
+      "chance": 1.0
+    }
+  ],
+  "behavior": "pack",
   "loot_table": "beast_common",
   "xp_value": 50,
-  "spawn_biomes": ["woodland", "forest", "tundra", "snow"],
+  "spawn_biomes": [
+    "woodland",
+    "forest",
+    "tundra",
+    "snow"
+  ],
   "spawn_dungeons": [],
   "spawn_density_overworld": 300,
   "spawn_density_dungeon": 0,
   "min_spawn_level": 0,
   "max_spawn_level": 0,
+  "feared_components": [
+    "fire"
+  ],
+  "fear_distance": 5,
   "min_distance_from_town": 35
 }

--- a/data/enemies/beasts/giant_centipede.json
+++ b/data/enemies/beasts/giant_centipede.json
@@ -5,6 +5,7 @@
   "cr": 0.25,
   "ascii_char": "c",
   "ascii_color": "#8B0000",
+  "creature_type": "beast",
   "stats": {
     "health": 4,
     "str": 5,
@@ -14,17 +15,31 @@
     "wis": 7,
     "cha": 3
   },
-  "yields": [
-    {"item_id": "chitin", "min_count": 1, "max_count": 2, "chance": 0.6},
-    {"item_id": "venom_sac", "min_count": 1, "max_count": 1, "chance": 0.2}
-  ],
-  "behavior": "aggressive",
   "base_damage": 2,
   "armor": 1,
+  "yields": [
+    {
+      "item_id": "chitin",
+      "min_count": 1,
+      "max_count": 2,
+      "chance": 0.6
+    },
+    {
+      "item_id": "venom_sac",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.2
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "insect_common",
   "xp_value": 10,
   "spawn_biomes": [],
-  "spawn_dungeons": ["natural_cave", "burial_barrow", "abandoned_mine"],
+  "spawn_dungeons": [
+    "natural_cave",
+    "burial_barrow",
+    "abandoned_mine"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 50,
   "min_spawn_level": 1,

--- a/data/enemies/beasts/giant_rat.json
+++ b/data/enemies/beasts/giant_rat.json
@@ -5,6 +5,7 @@
   "cr": 0.125,
   "ascii_char": "r",
   "ascii_color": "#4A4A4A",
+  "creature_type": "beast",
   "stats": {
     "health": 7,
     "str": 7,
@@ -14,20 +15,30 @@
     "wis": 10,
     "cha": 4
   },
-  "yields": [
-    {"item_id": "raw_meat", "min_count": 0, "max_count": 1, "chance": 0.5}
-  ],
-  "behavior": "aggressive",
   "base_damage": 2,
   "armor": 0,
-  "feared_components": ["fire"],
-  "fear_distance": 3,
+  "yields": [
+    {
+      "item_id": "raw_meat",
+      "min_count": 0,
+      "max_count": 1,
+      "chance": 0.5
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "rat_common",
   "xp_value": 8,
   "spawn_biomes": [],
-  "spawn_dungeons": ["sewers", "burial_barrow"],
+  "spawn_dungeons": [
+    "sewers",
+    "burial_barrow"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 50,
   "min_spawn_level": 1,
-  "max_spawn_level": 10
+  "max_spawn_level": 10,
+  "feared_components": [
+    "fire"
+  ],
+  "fear_distance": 3
 }

--- a/data/enemies/beasts/grave_rat.json
+++ b/data/enemies/beasts/grave_rat.json
@@ -5,6 +5,7 @@
   "cr": 0.125,
   "ascii_char": "r",
   "ascii_color": "#8B4513",
+  "creature_type": "beast",
   "stats": {
     "health": 8,
     "str": 4,
@@ -14,20 +15,28 @@
     "wis": 8,
     "cha": 3
   },
-  "yields": [
-    {"item_id": "raw_meat", "min_count": 0, "max_count": 1}
-  ],
-  "behavior": "aggressive",
   "base_damage": 2,
   "armor": 0,
-  "feared_components": ["fire"],
-  "fear_distance": 3,
+  "yields": [
+    {
+      "item_id": "raw_meat",
+      "min_count": 0,
+      "max_count": 1
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "rat_common",
   "xp_value": 5,
   "spawn_biomes": [],
-  "spawn_dungeons": ["burial_barrow"],
+  "spawn_dungeons": [
+    "burial_barrow"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 50,
   "min_spawn_level": 1,
-  "max_spawn_level": 15
+  "max_spawn_level": 15,
+  "feared_components": [
+    "fire"
+  ],
+  "fear_distance": 3
 }

--- a/data/enemies/beasts/rat.json
+++ b/data/enemies/beasts/rat.json
@@ -5,6 +5,7 @@
   "cr": 0,
   "ascii_char": "r",
   "ascii_color": "#8B4513",
+  "creature_type": "beast",
   "stats": {
     "health": 5,
     "str": 3,
@@ -14,20 +15,30 @@
     "wis": 8,
     "cha": 2
   },
-  "yields": [
-    {"item_id": "raw_meat", "min_count": 0, "max_count": 1, "chance": 0.5}
-  ],
-  "behavior": "aggressive",
   "base_damage": 1,
   "armor": 0,
-  "feared_components": ["fire"],
-  "fear_distance": 3,
+  "yields": [
+    {
+      "item_id": "raw_meat",
+      "min_count": 0,
+      "max_count": 1,
+      "chance": 0.5
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "rat_common",
   "xp_value": 3,
   "spawn_biomes": [],
-  "spawn_dungeons": ["sewers", "burial_barrow"],
+  "spawn_dungeons": [
+    "sewers",
+    "burial_barrow"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 40,
   "min_spawn_level": 1,
-  "max_spawn_level": 10
+  "max_spawn_level": 10,
+  "feared_components": [
+    "fire"
+  ],
+  "fear_distance": 3
 }

--- a/data/enemies/beasts/rat_swarm.json
+++ b/data/enemies/beasts/rat_swarm.json
@@ -5,6 +5,7 @@
   "cr": 0.25,
   "ascii_char": "R",
   "ascii_color": "#8B4513",
+  "creature_type": "beast",
   "stats": {
     "health": 20,
     "str": 6,
@@ -14,20 +15,29 @@
     "wis": 10,
     "cha": 2
   },
-  "yields": [
-    {"item_id": "raw_meat", "min_count": 1, "max_count": 3, "chance": 0.6}
-  ],
-  "behavior": "aggressive",
   "base_damage": 4,
   "armor": 0,
-  "feared_components": ["fire"],
-  "fear_distance": 4,
+  "yields": [
+    {
+      "item_id": "raw_meat",
+      "min_count": 1,
+      "max_count": 3,
+      "chance": 0.6
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "rat_common",
   "xp_value": 15,
   "spawn_biomes": [],
-  "spawn_dungeons": ["sewers"],
+  "spawn_dungeons": [
+    "sewers"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 80,
   "min_spawn_level": 1,
-  "max_spawn_level": 20
+  "max_spawn_level": 20,
+  "feared_components": [
+    "fire"
+  ],
+  "fear_distance": 4
 }

--- a/data/enemies/beasts/stirge.json
+++ b/data/enemies/beasts/stirge.json
@@ -5,6 +5,7 @@
   "cr": 0.125,
   "ascii_char": "i",
   "ascii_color": "#8B0000",
+  "creature_type": "beast",
   "stats": {
     "health": 2,
     "str": 4,
@@ -14,16 +15,28 @@
     "wis": 8,
     "cha": 6
   },
-  "yields": [
-    {"item_id": "stirge_wing", "min_count": 1, "max_count": 2, "chance": 0.6}
-  ],
-  "behavior": "aggressive",
   "base_damage": 2,
   "armor": 0,
+  "yields": [
+    {
+      "item_id": "stirge_wing",
+      "min_count": 1,
+      "max_count": 2,
+      "chance": 0.6
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "beast_common",
   "xp_value": 8,
-  "spawn_biomes": ["swamp", "marsh"],
-  "spawn_dungeons": ["natural_cave", "burial_barrow", "sewers"],
+  "spawn_biomes": [
+    "swamp",
+    "marsh"
+  ],
+  "spawn_dungeons": [
+    "natural_cave",
+    "burial_barrow",
+    "sewers"
+  ],
   "spawn_density_overworld": 300,
   "spawn_density_dungeon": 40,
   "min_spawn_level": 1,

--- a/data/enemies/beasts/woodland_wolf.json
+++ b/data/enemies/beasts/woodland_wolf.json
@@ -5,6 +5,7 @@
   "cr": 0.25,
   "ascii_char": "w",
   "ascii_color": "#A0A0A0",
+  "creature_type": "beast",
   "stats": {
     "health": 18,
     "str": 10,
@@ -14,21 +15,32 @@
     "wis": 10,
     "cha": 6
   },
-  "yields": [
-    {"item_id": "raw_meat", "min_count": 1, "max_count": 3}
-  ],
-  "behavior": "pack",
   "base_damage": 4,
   "armor": 0,
-  "feared_components": ["fire"],
-  "fear_distance": 4,
+  "yields": [
+    {
+      "item_id": "raw_meat",
+      "min_count": 1,
+      "max_count": 3
+    }
+  ],
+  "behavior": "pack",
   "loot_table": "beast_common",
   "xp_value": 30,
-  "spawn_biomes": ["woodland", "forest", "grassland", "tundra"],
+  "spawn_biomes": [
+    "woodland",
+    "forest",
+    "grassland",
+    "tundra"
+  ],
   "spawn_dungeons": [],
   "spawn_density_overworld": 400,
   "spawn_density_dungeon": 0,
   "min_spawn_level": 0,
   "max_spawn_level": 0,
+  "feared_components": [
+    "fire"
+  ],
+  "fear_distance": 4,
   "min_distance_from_town": 20
 }

--- a/data/enemies/constructs/possessed_statue.json
+++ b/data/enemies/constructs/possessed_statue.json
@@ -5,6 +5,7 @@
   "cr": 2,
   "ascii_char": "&",
   "ascii_color": "#A0A0A0",
+  "creature_type": "construct",
   "stats": {
     "health": 35,
     "str": 16,
@@ -14,17 +15,30 @@
     "wis": 10,
     "cha": 4
   },
-  "yields": [
-    {"item_id": "stone", "min_count": 2, "max_count": 5, "chance": 1.0},
-    {"item_id": "spirit_essence", "min_count": 1, "max_count": 1, "chance": 0.3}
-  ],
-  "behavior": "guardian",
   "base_damage": 8,
   "armor": 5,
+  "yields": [
+    {
+      "item_id": "stone",
+      "min_count": 2,
+      "max_count": 5,
+      "chance": 1.0
+    },
+    {
+      "item_id": "spirit_essence",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.3
+    }
+  ],
+  "behavior": "guardian",
   "loot_table": "construct_common",
   "xp_value": 50,
   "spawn_biomes": [],
-  "spawn_dungeons": ["temple_ruins", "wizard_tower"],
+  "spawn_dungeons": [
+    "temple_ruins",
+    "wizard_tower"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 120,
   "min_spawn_level": 3,

--- a/data/enemies/constructs/war_machine.json
+++ b/data/enemies/constructs/war_machine.json
@@ -5,6 +5,7 @@
   "cr": 5,
   "ascii_char": "M",
   "ascii_color": "#A0A0A0",
+  "creature_type": "construct",
   "stats": {
     "health": 60,
     "str": 18,
@@ -14,17 +15,30 @@
     "wis": 8,
     "cha": 2
   },
-  "yields": [
-    {"item_id": "iron_ore", "min_count": 3, "max_count": 6, "chance": 1.0},
-    {"item_id": "gears", "min_count": 1, "max_count": 3, "chance": 0.7}
-  ],
-  "behavior": "guardian",
   "base_damage": 14,
   "armor": 8,
+  "yields": [
+    {
+      "item_id": "iron_ore",
+      "min_count": 3,
+      "max_count": 6,
+      "chance": 1.0
+    },
+    {
+      "item_id": "gears",
+      "min_count": 1,
+      "max_count": 3,
+      "chance": 0.7
+    }
+  ],
+  "behavior": "guardian",
   "loot_table": "construct_rare",
   "xp_value": 120,
   "spawn_biomes": [],
-  "spawn_dungeons": ["military_compound", "ancient_fort"],
+  "spawn_dungeons": [
+    "military_compound",
+    "ancient_fort"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 250,
   "min_spawn_level": 8,

--- a/data/enemies/elementals/air_elemental.json
+++ b/data/enemies/elementals/air_elemental.json
@@ -5,6 +5,8 @@
   "cr": 5,
   "ascii_char": "A",
   "ascii_color": "#87CEEB",
+  "creature_type": "elemental",
+  "element_subtype": "air",
   "stats": {
     "health": 32,
     "str": 14,
@@ -14,16 +16,23 @@
     "wis": 10,
     "cha": 6
   },
-  "yields": [
-    {"item_id": "air_essence", "min_count": 1, "max_count": 2, "chance": 0.7}
-  ],
-  "behavior": "aggressive",
   "base_damage": 9,
   "armor": 1,
+  "yields": [
+    {
+      "item_id": "air_essence",
+      "min_count": 1,
+      "max_count": 2,
+      "chance": 0.7
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "elemental_common",
   "xp_value": 90,
   "spawn_biomes": [],
-  "spawn_dungeons": ["wizard_tower"],
+  "spawn_dungeons": [
+    "wizard_tower"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 160,
   "min_spawn_level": 8,

--- a/data/enemies/elementals/earth_elemental.json
+++ b/data/enemies/elementals/earth_elemental.json
@@ -5,6 +5,8 @@
   "cr": 5,
   "ascii_char": "E",
   "ascii_color": "#8B4513",
+  "creature_type": "elemental",
+  "element_subtype": "earth",
   "stats": {
     "health": 40,
     "str": 18,
@@ -14,22 +16,35 @@
     "wis": 10,
     "cha": 5
   },
-  "yields": [
-    {"item_id": "stone", "min_count": 3, "max_count": 6, "chance": 1.0},
-    {"item_id": "crystal_shard", "min_count": 1, "max_count": 2, "chance": 0.3}
-  ],
-  "behavior": "guardian",
   "base_damage": 10,
   "armor": 6,
-  "creature_type": "elemental",
   "elemental_resistances": {
     "piercing": -50,
     "lightning": 50
   },
+  "yields": [
+    {
+      "item_id": "stone",
+      "min_count": 3,
+      "max_count": 6,
+      "chance": 1.0
+    },
+    {
+      "item_id": "crystal_shard",
+      "min_count": 1,
+      "max_count": 2,
+      "chance": 0.3
+    }
+  ],
+  "behavior": "guardian",
   "loot_table": "elemental_common",
   "xp_value": 80,
   "spawn_biomes": [],
-  "spawn_dungeons": ["abandoned_mine", "natural_cave", "wizard_tower"],
+  "spawn_dungeons": [
+    "abandoned_mine",
+    "natural_cave",
+    "wizard_tower"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 150,
   "min_spawn_level": 10,

--- a/data/enemies/elementals/fire_elemental.json
+++ b/data/enemies/elementals/fire_elemental.json
@@ -5,6 +5,8 @@
   "cr": 5,
   "ascii_char": "F",
   "ascii_color": "#FF4500",
+  "creature_type": "elemental",
+  "element_subtype": "fire",
   "stats": {
     "health": 35,
     "str": 12,
@@ -14,22 +16,33 @@
     "wis": 10,
     "cha": 7
   },
-  "yields": [
-    {"item_id": "fire_essence", "min_count": 1, "max_count": 2, "chance": 0.7},
-    {"item_id": "ash", "min_count": 2, "max_count": 4, "chance": 0.9}
-  ],
-  "behavior": "aggressive",
   "base_damage": 10,
   "armor": 2,
-  "creature_type": "elemental",
   "elemental_resistances": {
     "fire": -100,
     "ice": 100
   },
+  "yields": [
+    {
+      "item_id": "fire_essence",
+      "min_count": 1,
+      "max_count": 2,
+      "chance": 0.7
+    },
+    {
+      "item_id": "ash",
+      "min_count": 2,
+      "max_count": 4,
+      "chance": 0.9
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "elemental_common",
   "xp_value": 90,
   "spawn_biomes": [],
-  "spawn_dungeons": ["wizard_tower"],
+  "spawn_dungeons": [
+    "wizard_tower"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 160,
   "min_spawn_level": 8,

--- a/data/enemies/humanoids/acolyte.json
+++ b/data/enemies/humanoids/acolyte.json
@@ -5,6 +5,7 @@
   "cr": 0.25,
   "ascii_char": "a",
   "ascii_color": "#FFD700",
+  "creature_type": "humanoid",
   "stats": {
     "health": 9,
     "str": 10,
@@ -14,17 +15,29 @@
     "wis": 14,
     "cha": 11
   },
-  "yields": [
-    {"item_id": "holy_symbol", "min_count": 1, "max_count": 1, "chance": 0.4},
-    {"item_id": "gold_coin", "min_count": 2, "max_count": 8, "chance": 0.5}
-  ],
-  "behavior": "aggressive",
   "base_damage": 3,
   "armor": 0,
+  "yields": [
+    {
+      "item_id": "holy_symbol",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.4
+    },
+    {
+      "item_id": "gold_coin",
+      "min_count": 2,
+      "max_count": 8,
+      "chance": 0.5
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "priest_common",
   "xp_value": 15,
   "spawn_biomes": [],
-  "spawn_dungeons": ["temple_ruins"],
+  "spawn_dungeons": [
+    "temple_ruins"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 60,
   "min_spawn_level": 1,

--- a/data/enemies/humanoids/bandit.json
+++ b/data/enemies/humanoids/bandit.json
@@ -5,6 +5,7 @@
   "cr": 0.125,
   "ascii_char": "h",
   "ascii_color": "#8B0000",
+  "creature_type": "humanoid",
   "stats": {
     "health": 18,
     "str": 12,
@@ -14,17 +15,33 @@
     "wis": 8,
     "cha": 8
   },
-  "yields": [
-    {"item_id": "gold_coin", "min_count": 5, "max_count": 15, "chance": 1.0},
-    {"item_id": "leather_armor", "min_count": 1, "max_count": 1, "chance": 0.7}
-  ],
-  "behavior": "aggressive",
   "base_damage": 5,
   "armor": 2,
+  "yields": [
+    {
+      "item_id": "gold_coin",
+      "min_count": 5,
+      "max_count": 15,
+      "chance": 1.0
+    },
+    {
+      "item_id": "leather_armor",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.7
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "bandit_common",
   "xp_value": 25,
-  "spawn_biomes": ["woodland", "forest", "grassland"],
-  "spawn_dungeons": ["ancient_fort"],
+  "spawn_biomes": [
+    "woodland",
+    "forest",
+    "grassland"
+  ],
+  "spawn_dungeons": [
+    "ancient_fort"
+  ],
   "spawn_density_overworld": 200,
   "spawn_density_dungeon": 100,
   "min_spawn_level": 1,

--- a/data/enemies/humanoids/bandit_captain.json
+++ b/data/enemies/humanoids/bandit_captain.json
@@ -5,6 +5,7 @@
   "cr": 2,
   "ascii_char": "H",
   "ascii_color": "#8B0000",
+  "creature_type": "humanoid",
   "stats": {
     "health": 65,
     "str": 15,
@@ -14,18 +15,35 @@
     "wis": 11,
     "cha": 14
   },
-  "yields": [
-    {"item_id": "gold_coin", "min_count": 20, "max_count": 60, "chance": 0.9},
-    {"item_id": "steel_sword", "min_count": 1, "max_count": 1, "chance": 0.4},
-    {"item_id": "leather_armor", "min_count": 1, "max_count": 1, "chance": 0.3}
-  ],
-  "behavior": "pack",
   "base_damage": 8,
   "armor": 3,
+  "yields": [
+    {
+      "item_id": "gold_coin",
+      "min_count": 20,
+      "max_count": 60,
+      "chance": 0.9
+    },
+    {
+      "item_id": "steel_sword",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.4
+    },
+    {
+      "item_id": "leather_armor",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.3
+    }
+  ],
+  "behavior": "pack",
   "loot_table": "bandit_rare",
   "xp_value": 75,
   "spawn_biomes": [],
-  "spawn_dungeons": ["ancient_fort"],
+  "spawn_dungeons": [
+    "ancient_fort"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 160,
   "min_spawn_level": 5,

--- a/data/enemies/humanoids/corrupted_miner.json
+++ b/data/enemies/humanoids/corrupted_miner.json
@@ -5,6 +5,7 @@
   "cr": 0.5,
   "ascii_char": "m",
   "ascii_color": "#8B6914",
+  "creature_type": "humanoid",
   "stats": {
     "health": 18,
     "str": 14,
@@ -14,17 +15,29 @@
     "wis": 6,
     "cha": 3
   },
-  "yields": [
-    {"item_id": "iron_ore", "min_count": 1, "max_count": 2, "chance": 0.5},
-    {"item_id": "pickaxe", "min_count": 1, "max_count": 1, "chance": 0.1}
-  ],
-  "behavior": "aggressive",
   "base_damage": 6,
   "armor": 1,
+  "yields": [
+    {
+      "item_id": "iron_ore",
+      "min_count": 1,
+      "max_count": 2,
+      "chance": 0.5
+    },
+    {
+      "item_id": "pickaxe",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.1
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "miner_common",
   "xp_value": 25,
   "spawn_biomes": [],
-  "spawn_dungeons": ["abandoned_mine"],
+  "spawn_dungeons": [
+    "abandoned_mine"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 100,
   "min_spawn_level": 1,

--- a/data/enemies/humanoids/criminal.json
+++ b/data/enemies/humanoids/criminal.json
@@ -5,6 +5,7 @@
   "cr": 0.125,
   "ascii_char": "c",
   "ascii_color": "#696969",
+  "creature_type": "humanoid",
   "stats": {
     "health": 15,
     "str": 11,
@@ -14,17 +15,29 @@
     "wis": 10,
     "cha": 10
   },
-  "yields": [
-    {"item_id": "gold_coin", "min_count": 10, "max_count": 30, "chance": 0.7},
-    {"item_id": "lockpick", "min_count": 1, "max_count": 2, "chance": 0.3}
-  ],
-  "behavior": "aggressive",
   "base_damage": 4,
   "armor": 1,
+  "yields": [
+    {
+      "item_id": "gold_coin",
+      "min_count": 10,
+      "max_count": 30,
+      "chance": 0.7
+    },
+    {
+      "item_id": "lockpick",
+      "min_count": 1,
+      "max_count": 2,
+      "chance": 0.3
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "thief_common",
   "xp_value": 20,
   "spawn_biomes": [],
-  "spawn_dungeons": ["sewers"],
+  "spawn_dungeons": [
+    "sewers"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 80,
   "min_spawn_level": 1,

--- a/data/enemies/humanoids/cult_fanatic.json
+++ b/data/enemies/humanoids/cult_fanatic.json
@@ -5,6 +5,7 @@
   "cr": 2,
   "ascii_char": "C",
   "ascii_color": "#800000",
+  "creature_type": "humanoid",
   "stats": {
     "health": 33,
     "str": 11,
@@ -14,18 +15,35 @@
     "wis": 13,
     "cha": 14
   },
-  "yields": [
-    {"item_id": "cultist_robe", "min_count": 1, "max_count": 1, "chance": 0.5},
-    {"item_id": "dark_tome", "min_count": 1, "max_count": 1, "chance": 0.2},
-    {"item_id": "gold_coin", "min_count": 10, "max_count": 30, "chance": 0.6}
-  ],
-  "behavior": "aggressive",
   "base_damage": 6,
   "armor": 1,
+  "yields": [
+    {
+      "item_id": "cultist_robe",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.5
+    },
+    {
+      "item_id": "dark_tome",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.2
+    },
+    {
+      "item_id": "gold_coin",
+      "min_count": 10,
+      "max_count": 30,
+      "chance": 0.6
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "cultist_rare",
   "xp_value": 60,
   "spawn_biomes": [],
-  "spawn_dungeons": ["temple_ruins"],
+  "spawn_dungeons": [
+    "temple_ruins"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 130,
   "min_spawn_level": 5,

--- a/data/enemies/humanoids/cultist.json
+++ b/data/enemies/humanoids/cultist.json
@@ -5,6 +5,7 @@
   "cr": 0.125,
   "ascii_char": "c",
   "ascii_color": "#800000",
+  "creature_type": "humanoid",
   "stats": {
     "health": 14,
     "str": 10,
@@ -14,17 +15,30 @@
     "wis": 8,
     "cha": 10
   },
-  "yields": [
-    {"item_id": "cultist_robe", "min_count": 1, "max_count": 1, "chance": 0.4},
-    {"item_id": "ritual_dagger", "min_count": 1, "max_count": 1, "chance": 0.2}
-  ],
-  "behavior": "aggressive",
   "base_damage": 4,
   "armor": 1,
+  "yields": [
+    {
+      "item_id": "cultist_robe",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.4
+    },
+    {
+      "item_id": "ritual_dagger",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.2
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "cultist_common",
   "xp_value": 20,
   "spawn_biomes": [],
-  "spawn_dungeons": ["temple_ruins", "burial_barrow"],
+  "spawn_dungeons": [
+    "temple_ruins",
+    "burial_barrow"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 90,
   "min_spawn_level": 1,

--- a/data/enemies/humanoids/deserter.json
+++ b/data/enemies/humanoids/deserter.json
@@ -5,6 +5,7 @@
   "cr": 0.5,
   "ascii_char": "d",
   "ascii_color": "#556B2F",
+  "creature_type": "humanoid",
   "stats": {
     "health": 22,
     "str": 14,
@@ -14,17 +15,34 @@
     "wis": 10,
     "cha": 8
   },
-  "yields": [
-    {"item_id": "iron_sword", "min_count": 1, "max_count": 1, "chance": 0.3},
-    {"item_id": "chain_mail", "min_count": 1, "max_count": 1, "chance": 0.15}
-  ],
-  "behavior": "aggressive",
   "base_damage": 6,
   "armor": 3,
+  "yields": [
+    {
+      "item_id": "iron_sword",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.3
+    },
+    {
+      "item_id": "chain_mail",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.15
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "soldier_common",
   "xp_value": 35,
-  "spawn_biomes": ["woodland", "forest", "grassland"],
-  "spawn_dungeons": ["military_compound", "ancient_fort"],
+  "spawn_biomes": [
+    "woodland",
+    "forest",
+    "grassland"
+  ],
+  "spawn_dungeons": [
+    "military_compound",
+    "ancient_fort"
+  ],
   "spawn_density_overworld": 150,
   "spawn_density_dungeon": 120,
   "min_spawn_level": 1,

--- a/data/enemies/humanoids/fallen_priest.json
+++ b/data/enemies/humanoids/fallen_priest.json
@@ -5,6 +5,7 @@
   "cr": 2,
   "ascii_char": "P",
   "ascii_color": "#4B0082",
+  "creature_type": "humanoid",
   "stats": {
     "health": 30,
     "str": 10,
@@ -14,17 +15,29 @@
     "wis": 14,
     "cha": 12
   },
-  "yields": [
-    {"item_id": "unholy_symbol", "min_count": 1, "max_count": 1, "chance": 0.5},
-    {"item_id": "dark_tome", "min_count": 1, "max_count": 1, "chance": 0.2}
-  ],
-  "behavior": "aggressive",
   "base_damage": 6,
   "armor": 2,
+  "yields": [
+    {
+      "item_id": "unholy_symbol",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.5
+    },
+    {
+      "item_id": "dark_tome",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.2
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "priest_rare",
   "xp_value": 75,
   "spawn_biomes": [],
-  "spawn_dungeons": ["temple_ruins"],
+  "spawn_dungeons": [
+    "temple_ruins"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 160,
   "min_spawn_level": 8,

--- a/data/enemies/humanoids/guard_captain.json
+++ b/data/enemies/humanoids/guard_captain.json
@@ -5,6 +5,7 @@
   "cr": 3,
   "ascii_char": "C",
   "ascii_color": "#FFD700",
+  "creature_type": "humanoid",
   "stats": {
     "health": 40,
     "str": 16,
@@ -14,18 +15,36 @@
     "wis": 12,
     "cha": 14
   },
-  "yields": [
-    {"item_id": "steel_sword", "min_count": 1, "max_count": 1, "chance": 0.5},
-    {"item_id": "plate_armor", "min_count": 1, "max_count": 1, "chance": 0.25},
-    {"item_id": "gold_coin", "min_count": 20, "max_count": 50, "chance": 0.8}
-  ],
-  "behavior": "guardian",
   "base_damage": 10,
   "armor": 5,
+  "yields": [
+    {
+      "item_id": "steel_sword",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.5
+    },
+    {
+      "item_id": "plate_armor",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.25
+    },
+    {
+      "item_id": "gold_coin",
+      "min_count": 20,
+      "max_count": 50,
+      "chance": 0.8
+    }
+  ],
+  "behavior": "guardian",
   "loot_table": "captain_rare",
   "xp_value": 80,
   "spawn_biomes": [],
-  "spawn_dungeons": ["military_compound", "ancient_fort"],
+  "spawn_dungeons": [
+    "military_compound",
+    "ancient_fort"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 180,
   "min_spawn_level": 5,

--- a/data/enemies/humanoids/soldier.json
+++ b/data/enemies/humanoids/soldier.json
@@ -5,6 +5,7 @@
   "cr": 0.5,
   "ascii_char": "s",
   "ascii_color": "#4682B4",
+  "creature_type": "humanoid",
   "stats": {
     "health": 25,
     "str": 14,
@@ -14,17 +15,30 @@
     "wis": 10,
     "cha": 10
   },
-  "yields": [
-    {"item_id": "iron_sword", "min_count": 1, "max_count": 1, "chance": 0.4},
-    {"item_id": "chain_mail", "min_count": 1, "max_count": 1, "chance": 0.2}
-  ],
-  "behavior": "guardian",
   "base_damage": 6,
   "armor": 4,
+  "yields": [
+    {
+      "item_id": "iron_sword",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.4
+    },
+    {
+      "item_id": "chain_mail",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.2
+    }
+  ],
+  "behavior": "guardian",
   "loot_table": "soldier_common",
   "xp_value": 35,
   "spawn_biomes": [],
-  "spawn_dungeons": ["military_compound", "ancient_fort"],
+  "spawn_dungeons": [
+    "military_compound",
+    "ancient_fort"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 100,
   "min_spawn_level": 1,

--- a/data/enemies/humanoids/thug.json
+++ b/data/enemies/humanoids/thug.json
@@ -5,6 +5,7 @@
   "cr": 0.5,
   "ascii_char": "h",
   "ascii_color": "#696969",
+  "creature_type": "humanoid",
   "stats": {
     "health": 32,
     "str": 15,
@@ -14,17 +15,29 @@
     "wis": 10,
     "cha": 11
   },
-  "yields": [
-    {"item_id": "gold_coin", "min_count": 3, "max_count": 12, "chance": 0.7},
-    {"item_id": "club", "min_count": 1, "max_count": 1, "chance": 0.4}
-  ],
-  "behavior": "aggressive",
   "base_damage": 5,
   "armor": 1,
+  "yields": [
+    {
+      "item_id": "gold_coin",
+      "min_count": 3,
+      "max_count": 12,
+      "chance": 0.7
+    },
+    {
+      "item_id": "club",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.4
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "thief_common",
   "xp_value": 25,
   "spawn_biomes": [],
-  "spawn_dungeons": ["sewers"],
+  "spawn_dungeons": [
+    "sewers"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 80,
   "min_spawn_level": 1,

--- a/data/enemies/humanoids/tomb_robber.json
+++ b/data/enemies/humanoids/tomb_robber.json
@@ -5,6 +5,7 @@
   "cr": 0.25,
   "ascii_char": "t",
   "ascii_color": "#8B7355",
+  "creature_type": "humanoid",
   "stats": {
     "health": 15,
     "str": 10,
@@ -14,18 +15,35 @@
     "wis": 10,
     "cha": 8
   },
-  "yields": [
-    {"item_id": "gold_coin", "min_count": 5, "max_count": 20, "chance": 0.8},
-    {"item_id": "torch", "min_count": 1, "max_count": 2, "chance": 0.5},
-    {"item_id": "lockpick", "min_count": 1, "max_count": 1, "chance": 0.3}
-  ],
-  "behavior": "aggressive",
   "base_damage": 4,
   "armor": 1,
+  "yields": [
+    {
+      "item_id": "gold_coin",
+      "min_count": 5,
+      "max_count": 20,
+      "chance": 0.8
+    },
+    {
+      "item_id": "torch",
+      "min_count": 1,
+      "max_count": 2,
+      "chance": 0.5
+    },
+    {
+      "item_id": "lockpick",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.3
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "thief_common",
   "xp_value": 18,
   "spawn_biomes": [],
-  "spawn_dungeons": ["burial_barrow"],
+  "spawn_dungeons": [
+    "burial_barrow"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 70,
   "min_spawn_level": 1,

--- a/data/enemies/monstrosities/giant_beetle.json
+++ b/data/enemies/monstrosities/giant_beetle.json
@@ -5,6 +5,7 @@
   "cr": 0.5,
   "ascii_char": "b",
   "ascii_color": "#2F4F4F",
+  "creature_type": "monstrosity",
   "stats": {
     "health": 22,
     "str": 12,
@@ -14,16 +15,25 @@
     "wis": 6,
     "cha": 2
   },
-  "yields": [
-    {"item_id": "chitin", "min_count": 1, "max_count": 3, "chance": 0.7}
-  ],
-  "behavior": "aggressive",
   "base_damage": 5,
   "armor": 4,
+  "yields": [
+    {
+      "item_id": "chitin",
+      "min_count": 1,
+      "max_count": 3,
+      "chance": 0.7
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "insect_common",
   "xp_value": 30,
   "spawn_biomes": [],
-  "spawn_dungeons": ["natural_cave", "abandoned_mine", "sewers"],
+  "spawn_dungeons": [
+    "natural_cave",
+    "abandoned_mine",
+    "sewers"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 120,
   "min_spawn_level": 5,

--- a/data/enemies/monstrosities/giant_spider.json
+++ b/data/enemies/monstrosities/giant_spider.json
@@ -5,6 +5,7 @@
   "cr": 1,
   "ascii_char": "S",
   "ascii_color": "#800080",
+  "creature_type": "monstrosity",
   "stats": {
     "health": 16,
     "str": 10,
@@ -14,17 +15,34 @@
     "wis": 10,
     "cha": 2
   },
-  "yields": [
-    {"item_id": "spider_silk", "min_count": 1, "max_count": 3, "chance": 0.7},
-    {"item_id": "venom_sac", "min_count": 1, "max_count": 1, "chance": 0.3}
-  ],
-  "behavior": "aggressive",
   "base_damage": 4,
   "armor": 1,
+  "yields": [
+    {
+      "item_id": "spider_silk",
+      "min_count": 1,
+      "max_count": 3,
+      "chance": 0.7
+    },
+    {
+      "item_id": "venom_sac",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.3
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "spider_common",
   "xp_value": 20,
-  "spawn_biomes": ["forest", "woodland"],
-  "spawn_dungeons": ["natural_cave", "burial_barrow", "abandoned_mine"],
+  "spawn_biomes": [
+    "forest",
+    "woodland"
+  ],
+  "spawn_dungeons": [
+    "natural_cave",
+    "burial_barrow",
+    "abandoned_mine"
+  ],
   "spawn_density_overworld": 80,
   "spawn_density_dungeon": 100,
   "min_spawn_level": 5,

--- a/data/enemies/monstrosities/ogre.json
+++ b/data/enemies/monstrosities/ogre.json
@@ -5,6 +5,7 @@
   "cr": 2,
   "ascii_char": "O",
   "ascii_color": "#228B22",
+  "creature_type": "monstrosity",
   "stats": {
     "health": 60,
     "str": 20,
@@ -14,17 +15,33 @@
     "wis": 8,
     "cha": 4
   },
-  "yields": [
-    {"item_id": "ogre_club", "min_count": 1, "max_count": 1, "chance": 0.5},
-    {"item_id": "raw_meat", "min_count": 3, "max_count": 5, "chance": 0.8}
-  ],
-  "behavior": "aggressive",
   "base_damage": 12,
   "armor": 3,
+  "yields": [
+    {
+      "item_id": "ogre_club",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.5
+    },
+    {
+      "item_id": "raw_meat",
+      "min_count": 3,
+      "max_count": 5,
+      "chance": 0.8
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "ogre_common",
   "xp_value": 100,
-  "spawn_biomes": ["mountains", "rocky_hills", "barren_rock"],
-  "spawn_dungeons": ["natural_cave"],
+  "spawn_biomes": [
+    "mountains",
+    "rocky_hills",
+    "barren_rock"
+  ],
+  "spawn_dungeons": [
+    "natural_cave"
+  ],
   "spawn_density_overworld": 150,
   "spawn_density_dungeon": 200,
   "min_spawn_level": 5,

--- a/data/enemies/oozes/sewer_ooze.json
+++ b/data/enemies/oozes/sewer_ooze.json
@@ -5,6 +5,7 @@
   "cr": 0.5,
   "ascii_char": "o",
   "ascii_color": "#556B2F",
+  "creature_type": "ooze",
   "stats": {
     "health": 20,
     "str": 8,
@@ -14,16 +15,23 @@
     "wis": 4,
     "cha": 1
   },
-  "yields": [
-    {"item_id": "toxic_residue", "min_count": 1, "max_count": 2, "chance": 0.7}
-  ],
-  "behavior": "aggressive",
   "base_damage": 3,
   "armor": 0,
+  "yields": [
+    {
+      "item_id": "toxic_residue",
+      "min_count": 1,
+      "max_count": 2,
+      "chance": 0.7
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "ooze_common",
   "xp_value": 20,
   "spawn_biomes": [],
-  "spawn_dungeons": ["sewers"],
+  "spawn_dungeons": [
+    "sewers"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 80,
   "min_spawn_level": 2,

--- a/data/enemies/summons/summoned_skeleton.json
+++ b/data/enemies/summons/summoned_skeleton.json
@@ -4,9 +4,7 @@
   "description": "An animated skeleton that obeys your commands.",
   "ascii_char": "s",
   "ascii_color": "#DDDDCC",
-  "base_health": 25,
-  "base_damage": 5,
-  "armor": 2,
+  "creature_type": "undead",
   "attributes": {
     "STR": 14,
     "DEX": 10,
@@ -15,6 +13,9 @@
     "WIS": 8,
     "CHA": 4
   },
+  "base_health": 25,
+  "base_damage": 5,
+  "armor": 2,
   "behavior": "summoned",
   "faction": "player"
 }

--- a/data/enemies/summons/summoned_wolf.json
+++ b/data/enemies/summons/summoned_wolf.json
@@ -4,9 +4,7 @@
   "description": "A ghostly wolf bound to your service.",
   "ascii_char": "w",
   "ascii_color": "#88AAFF",
-  "base_health": 20,
-  "base_damage": 6,
-  "armor": 0,
+  "creature_type": "beast",
   "attributes": {
     "STR": 12,
     "DEX": 14,
@@ -15,6 +13,9 @@
     "WIS": 10,
     "CHA": 6
   },
+  "base_health": 20,
+  "base_damage": 6,
+  "armor": 0,
   "behavior": "summoned",
   "faction": "player"
 }

--- a/data/enemies/undead/barrow_lord.json
+++ b/data/enemies/undead/barrow_lord.json
@@ -5,6 +5,7 @@
   "cr": 6,
   "ascii_char": "L",
   "ascii_color": "#00FF00",
+  "creature_type": "undead",
   "stats": {
     "health": 80,
     "str": 16,
@@ -14,17 +15,29 @@
     "wis": 14,
     "cha": 14
   },
-  "yields": [
-    {"item_id": "ancient_crown", "min_count": 1, "max_count": 1, "chance": 1.0},
-    {"item_id": "ectoplasm", "min_count": 2, "max_count": 4, "chance": 1.0}
-  ],
-  "behavior": "guardian",
   "base_damage": 12,
   "armor": 5,
+  "yields": [
+    {
+      "item_id": "ancient_crown",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 1.0
+    },
+    {
+      "item_id": "ectoplasm",
+      "min_count": 2,
+      "max_count": 4,
+      "chance": 1.0
+    }
+  ],
+  "behavior": "guardian",
   "loot_table": "undead_boss",
   "xp_value": 500,
   "spawn_biomes": [],
-  "spawn_dungeons": ["burial_barrow"],
+  "spawn_dungeons": [
+    "burial_barrow"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 0,
   "min_spawn_level": 20,

--- a/data/enemies/undead/ghast.json
+++ b/data/enemies/undead/ghast.json
@@ -5,6 +5,7 @@
   "cr": 2,
   "ascii_char": "G",
   "ascii_color": "#5F9EA0",
+  "creature_type": "undead",
   "stats": {
     "health": 36,
     "str": 16,
@@ -14,17 +15,29 @@
     "wis": 10,
     "cha": 8
   },
-  "yields": [
-    {"item_id": "ghoul_claw", "min_count": 2, "max_count": 4, "chance": 0.8},
-    {"item_id": "ectoplasm", "min_count": 1, "max_count": 2, "chance": 0.5}
-  ],
-  "behavior": "pack",
   "base_damage": 8,
   "armor": 2,
+  "yields": [
+    {
+      "item_id": "ghoul_claw",
+      "min_count": 2,
+      "max_count": 4,
+      "chance": 0.8
+    },
+    {
+      "item_id": "ectoplasm",
+      "min_count": 1,
+      "max_count": 2,
+      "chance": 0.5
+    }
+  ],
+  "behavior": "pack",
   "loot_table": "undead_rare",
   "xp_value": 75,
   "spawn_biomes": [],
-  "spawn_dungeons": ["burial_barrow"],
+  "spawn_dungeons": [
+    "burial_barrow"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 140,
   "min_spawn_level": 5,

--- a/data/enemies/undead/ghoul.json
+++ b/data/enemies/undead/ghoul.json
@@ -5,6 +5,7 @@
   "cr": 1,
   "ascii_char": "g",
   "ascii_color": "#708090",
+  "creature_type": "undead",
   "stats": {
     "health": 22,
     "str": 13,
@@ -14,17 +15,30 @@
     "wis": 10,
     "cha": 6
   },
-  "yields": [
-    {"item_id": "ghoul_claw", "min_count": 1, "max_count": 2, "chance": 0.6},
-    {"item_id": "ectoplasm", "min_count": 1, "max_count": 1, "chance": 0.3}
-  ],
-  "behavior": "aggressive",
   "base_damage": 6,
   "armor": 1,
+  "yields": [
+    {
+      "item_id": "ghoul_claw",
+      "min_count": 1,
+      "max_count": 2,
+      "chance": 0.6
+    },
+    {
+      "item_id": "ectoplasm",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.3
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "undead_common",
   "xp_value": 35,
   "spawn_biomes": [],
-  "spawn_dungeons": ["burial_barrow", "temple_ruins"],
+  "spawn_dungeons": [
+    "burial_barrow",
+    "temple_ruins"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 100,
   "min_spawn_level": 3,

--- a/data/enemies/undead/necromancer.json
+++ b/data/enemies/undead/necromancer.json
@@ -5,7 +5,7 @@
   "cr": 5,
   "ascii_char": "N",
   "ascii_color": "#660066",
-  "creature_type": "humanoid",
+  "creature_type": "undead",
   "stats": {
     "health": 45,
     "str": 9,
@@ -15,23 +15,41 @@
     "wis": 14,
     "cha": 12
   },
-  "spellcaster": {
-    "max_mana": 80,
-    "spells": ["drain_life", "summon_skeleton", "weakness"]
-  },
-  "yields": [
-    {"item_id": "mana_crystal", "min_count": 1, "max_count": 3, "chance": 0.6},
-    {"item_id": "arcane_essence", "min_count": 1, "max_count": 1, "chance": 0.25}
-  ],
-  "behavior": "spellcaster_defensive",
   "base_damage": 5,
   "armor": 1,
+  "yields": [
+    {
+      "item_id": "mana_crystal",
+      "min_count": 1,
+      "max_count": 3,
+      "chance": 0.6
+    },
+    {
+      "item_id": "arcane_essence",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.25
+    }
+  ],
+  "behavior": "spellcaster_defensive",
   "loot_table": "necromancer_loot",
   "xp_value": 120,
   "spawn_biomes": [],
-  "spawn_dungeons": ["burial_barrow", "crypt", "dark_sanctum"],
+  "spawn_dungeons": [
+    "burial_barrow",
+    "crypt",
+    "dark_sanctum"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 30,
   "min_spawn_level": 8,
-  "max_spawn_level": 50
+  "max_spawn_level": 50,
+  "spellcaster": {
+    "max_mana": 80,
+    "spells": [
+      "drain_life",
+      "summon_skeleton",
+      "weakness"
+    ]
+  }
 }

--- a/data/enemies/undead/plague_victim.json
+++ b/data/enemies/undead/plague_victim.json
@@ -5,6 +5,7 @@
   "cr": 0.25,
   "ascii_char": "p",
   "ascii_color": "#9ACD32",
+  "creature_type": "undead",
   "stats": {
     "health": 12,
     "str": 8,
@@ -14,16 +15,23 @@
     "wis": 4,
     "cha": 2
   },
-  "yields": [
-    {"item_id": "plague_sample", "min_count": 1, "max_count": 1, "chance": 0.4}
-  ],
-  "behavior": "aggressive",
   "base_damage": 3,
   "armor": 0,
+  "yields": [
+    {
+      "item_id": "plague_sample",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.4
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "undead_common",
   "xp_value": 15,
   "spawn_biomes": [],
-  "spawn_dungeons": ["sewers"],
+  "spawn_dungeons": [
+    "sewers"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 70,
   "min_spawn_level": 3,

--- a/data/enemies/undead/skeleton_archer.json
+++ b/data/enemies/undead/skeleton_archer.json
@@ -5,6 +5,7 @@
   "cr": 0.25,
   "ascii_char": "s",
   "ascii_color": "#D3D3D3",
+  "creature_type": "undead",
   "stats": {
     "health": 13,
     "str": 8,
@@ -14,22 +15,35 @@
     "wis": 8,
     "cha": 3
   },
-  "yields": [
-    {"item_id": "bone", "min_count": 1, "max_count": 2, "chance": 0.8},
-    {"item_id": "arrow", "min_count": 3, "max_count": 8, "chance": 0.6}
-  ],
-  "behavior": "aggressive",
   "base_damage": 4,
   "armor": 1,
-  "attack_type": "ranged",
-  "attack_range": 6,
-  "ammunition_type": "arrow",
+  "yields": [
+    {
+      "item_id": "bone",
+      "min_count": 1,
+      "max_count": 2,
+      "chance": 0.8
+    },
+    {
+      "item_id": "arrow",
+      "min_count": 3,
+      "max_count": 8,
+      "chance": 0.6
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "undead_common",
   "xp_value": 20,
   "spawn_biomes": [],
-  "spawn_dungeons": ["burial_barrow", "military_compound"],
+  "spawn_dungeons": [
+    "burial_barrow",
+    "military_compound"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 90,
   "min_spawn_level": 2,
-  "max_spawn_level": 15
+  "max_spawn_level": 15,
+  "attack_type": "ranged",
+  "attack_range": 6,
+  "ammunition_type": "arrow"
 }

--- a/data/enemies/undead/skeleton_warrior.json
+++ b/data/enemies/undead/skeleton_warrior.json
@@ -5,6 +5,7 @@
   "cr": 0.5,
   "ascii_char": "S",
   "ascii_color": "#C0C0C0",
+  "creature_type": "undead",
   "stats": {
     "health": 20,
     "str": 14,
@@ -14,17 +15,30 @@
     "wis": 8,
     "cha": 4
   },
-  "yields": [
-    {"item_id": "bone", "min_count": 2, "max_count": 4, "chance": 0.9},
-    {"item_id": "rusty_sword", "min_count": 1, "max_count": 1, "chance": 0.3}
-  ],
-  "behavior": "guardian",
   "base_damage": 6,
   "armor": 3,
+  "yields": [
+    {
+      "item_id": "bone",
+      "min_count": 2,
+      "max_count": 4,
+      "chance": 0.9
+    },
+    {
+      "item_id": "rusty_sword",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.3
+    }
+  ],
+  "behavior": "guardian",
   "loot_table": "undead_common",
   "xp_value": 35,
   "spawn_biomes": [],
-  "spawn_dungeons": ["burial_barrow", "military_compound"],
+  "spawn_dungeons": [
+    "burial_barrow",
+    "military_compound"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 110,
   "min_spawn_level": 3,

--- a/data/enemies/undead/specter.json
+++ b/data/enemies/undead/specter.json
@@ -5,6 +5,7 @@
   "cr": 1,
   "ascii_char": "p",
   "ascii_color": "#4682B4",
+  "creature_type": "undead",
   "stats": {
     "health": 22,
     "str": 1,
@@ -14,16 +15,25 @@
     "wis": 10,
     "cha": 11
   },
-  "yields": [
-    {"item_id": "ectoplasm", "min_count": 1, "max_count": 2, "chance": 0.7}
-  ],
-  "behavior": "aggressive",
   "base_damage": 5,
   "armor": 0,
+  "yields": [
+    {
+      "item_id": "ectoplasm",
+      "min_count": 1,
+      "max_count": 2,
+      "chance": 0.7
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "undead_common",
   "xp_value": 40,
   "spawn_biomes": [],
-  "spawn_dungeons": ["burial_barrow", "temple_ruins", "wizard_tower"],
+  "spawn_dungeons": [
+    "burial_barrow",
+    "temple_ruins",
+    "wizard_tower"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 90,
   "min_spawn_level": 4,

--- a/data/enemies/undead/wight.json
+++ b/data/enemies/undead/wight.json
@@ -5,6 +5,7 @@
   "cr": 3,
   "ascii_char": "w",
   "ascii_color": "#33DD33",
+  "creature_type": "undead",
   "stats": {
     "health": 20,
     "str": 11,
@@ -14,16 +15,24 @@
     "wis": 7,
     "cha": 5
   },
-  "yields": [
-    {"item_id": "ectoplasm", "min_count": 1, "max_count": 2, "chance": 0.6}
-  ],
-  "behavior": "guardian",
   "base_damage": 5,
   "armor": 2,
+  "yields": [
+    {
+      "item_id": "ectoplasm",
+      "min_count": 1,
+      "max_count": 2,
+      "chance": 0.6
+    }
+  ],
+  "behavior": "guardian",
   "loot_table": "undead_common",
   "xp_value": 35,
   "spawn_biomes": [],
-  "spawn_dungeons": ["burial_barrow", "temple_ruins"],
+  "spawn_dungeons": [
+    "burial_barrow",
+    "temple_ruins"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 120,
   "min_spawn_level": 5,

--- a/data/enemies/undead/wraith.json
+++ b/data/enemies/undead/wraith.json
@@ -5,6 +5,7 @@
   "cr": 5,
   "ascii_char": "W",
   "ascii_color": "#2F4F4F",
+  "creature_type": "undead",
   "stats": {
     "health": 67,
     "str": 6,
@@ -14,17 +15,30 @@
     "wis": 14,
     "cha": 15
   },
-  "yields": [
-    {"item_id": "ectoplasm", "min_count": 2, "max_count": 4, "chance": 0.9},
-    {"item_id": "soul_gem", "min_count": 1, "max_count": 1, "chance": 0.2}
-  ],
-  "behavior": "aggressive",
   "base_damage": 10,
   "armor": 0,
+  "yields": [
+    {
+      "item_id": "ectoplasm",
+      "min_count": 2,
+      "max_count": 4,
+      "chance": 0.9
+    },
+    {
+      "item_id": "soul_gem",
+      "min_count": 1,
+      "max_count": 1,
+      "chance": 0.2
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "undead_rare",
   "xp_value": 200,
   "spawn_biomes": [],
-  "spawn_dungeons": ["burial_barrow", "temple_ruins"],
+  "spawn_dungeons": [
+    "burial_barrow",
+    "temple_ruins"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 200,
   "min_spawn_level": 10,

--- a/data/enemies/undead/zombie.json
+++ b/data/enemies/undead/zombie.json
@@ -5,6 +5,7 @@
   "cr": 0.25,
   "ascii_char": "z",
   "ascii_color": "#556B2F",
+  "creature_type": "undead",
   "stats": {
     "health": 22,
     "str": 13,
@@ -14,16 +15,25 @@
     "wis": 6,
     "cha": 5
   },
-  "yields": [
-    {"item_id": "rotten_flesh", "min_count": 1, "max_count": 2, "chance": 0.7}
-  ],
-  "behavior": "aggressive",
   "base_damage": 4,
   "armor": 0,
+  "yields": [
+    {
+      "item_id": "rotten_flesh",
+      "min_count": 1,
+      "max_count": 2,
+      "chance": 0.7
+    }
+  ],
+  "behavior": "aggressive",
   "loot_table": "undead_common",
   "xp_value": 20,
   "spawn_biomes": [],
-  "spawn_dungeons": ["burial_barrow", "sewers", "temple_ruins"],
+  "spawn_dungeons": [
+    "burial_barrow",
+    "sewers",
+    "temple_ruins"
+  ],
   "spawn_density_overworld": 0,
   "spawn_density_dungeon": 70,
   "min_spawn_level": 1,

--- a/docs/data/enemies.md
+++ b/docs/data/enemies.md
@@ -36,8 +36,64 @@ Enemy definitions specify all hostile creatures in the game including their stat
 | `max_spawn_level` | int | 50 | Latest floor to spawn | DungeonManager |
 | `feared_components` | array | [] | Components that cause fear | Enemy AI |
 | `fear_distance` | int | 0 | Fear reaction distance | Enemy AI |
+| `creature_type` | string | "humanoid" | Creature classification for resistances | CreatureTypeManager |
+| `element_subtype` | string | "" | Elemental subtype (fire, ice, etc.) | CreatureTypeManager |
+| `elemental_resistances` | object | {} | Per-creature damage resistances | ElementalSystem |
 
 ## Property Details
+
+### `creature_type`
+**Type**: string
+**Default**: "humanoid"
+
+Classification used for type-level damage resistances and special rules. Valid types:
+- `humanoid` - Intelligent bipedal creatures
+- `undead` - Reanimated corpses (immune to poison, heals from necrotic)
+- `construct` - Animated objects (immune to poison)
+- `elemental` - Elemental beings (immune to poison)
+- `demon` - Fiendish beings (resistant to fire)
+- `ooze` - Amorphous creatures (resistant to physical)
+- `beast` - Natural animals
+- `aberration` - Alien beings
+- `monstrosity` - Unnatural creatures
+
+```json
+"creature_type": "undead"
+```
+
+### `element_subtype`
+**Type**: string
+**Default**: ""
+
+Optional subtype for elemental creatures. Provides additional resistances:
+- `fire` - Immune to fire, vulnerable to ice
+- `ice` - Immune to ice, vulnerable to fire
+- `earth` - Resistant to piercing/bludgeoning
+- `air` - Resistant to lightning
+
+```json
+"creature_type": "elemental",
+"element_subtype": "fire"
+```
+
+### `elemental_resistances`
+**Type**: object
+**Default**: {}
+
+Per-creature damage resistance overrides. Values from -100 (immune) to +100 (vulnerable).
+
+```json
+"elemental_resistances": {
+  "fire": -100,
+  "ice": 100,
+  "poison": -100
+}
+```
+
+Resistance precedence (highest priority wins):
+1. Per-creature `elemental_resistances`
+2. Element subtype resistances
+3. Creature type base resistances
 
 ### `stats`
 **Type**: object

--- a/docs/systems/creature-type-manager.md
+++ b/docs/systems/creature-type-manager.md
@@ -1,0 +1,132 @@
+# Creature Type Manager
+
+**Location**: `autoload/creature_type_manager.gd`
+**Autoload Name**: CreatureTypeManager
+
+## Overview
+
+The CreatureTypeManager handles creature type definitions and type-level damage resistances. It provides a data-driven system for configuring creature type properties without hardcoding values in game systems.
+
+## Features
+
+- Loads creature type definitions from JSON files
+- Provides type-level and subtype-level resistances
+- Supports special rules (immune_to_poison, heals_from_necrotic, etc.)
+- Merges resistances with proper precedence
+
+## Resistance Precedence
+
+When calculating elemental resistances, values are merged in this order (highest priority wins):
+
+1. **Per-creature** - `elemental_resistances` in individual enemy JSON
+2. **Subtype-level** - Subtype resistances (e.g., fire elemental fire immunity)
+3. **Type-level** - Base resistances from creature type definition
+
+## API Reference
+
+### Loading
+
+```gdscript
+# Automatically loads all JSON from data/creature_types/ on _ready()
+```
+
+### Type Lookup
+
+```gdscript
+# Get full type definition
+var type_def = CreatureTypeManager.get_creature_type("undead")
+
+# Get all type IDs
+var types = CreatureTypeManager.get_all_creature_type_ids()
+```
+
+### Display Names
+
+```gdscript
+# Get display name for type
+var name = CreatureTypeManager.get_type_display_name("undead")  # "Undead"
+
+# Get display name for subtype
+var name = CreatureTypeManager.get_subtype_display_name("elemental", "fire")  # "Fire Elemental"
+
+# Get 3-character abbreviation
+var abbrev = CreatureTypeManager.get_type_abbreviation("undead")  # "UND"
+```
+
+### Resistances
+
+```gdscript
+# Get merged resistances for a creature
+var resistances = CreatureTypeManager.get_merged_resistances(
+    creature_type,      # e.g., "elemental"
+    element_subtype,    # e.g., "fire" (optional)
+    creature_resistances # per-creature overrides (optional)
+)
+# Returns: {"fire": -100, "ice": 100, "poison": -100}
+```
+
+### Special Rules
+
+```gdscript
+# Check if type has a special rule
+if CreatureTypeManager.has_special_rule("undead", "heals_from_necrotic"):
+    # Heal instead of damage
+
+# Get numeric rule value
+var bonus = CreatureTypeManager.get_special_rule_value("undead", "radiant_vulnerability_bonus", 50)
+```
+
+### Appearance
+
+```gdscript
+# Get type color for UI
+var color = CreatureTypeManager.get_type_color("undead")  # "#708090"
+
+# Get description
+var desc = CreatureTypeManager.get_type_description("undead")
+```
+
+## Creature Types
+
+| Type | Abbreviation | Key Resistances | Special Rules |
+|------|--------------|-----------------|---------------|
+| humanoid | HUM | None | - |
+| undead | UND | poison: -100, necrotic: -100 | heals_from_necrotic, vulnerable_to_radiant, immune_to_poison |
+| construct | CON | poison: -100, necrotic: -50 | immune_to_poison, immune_to_mind_control |
+| elemental | ELE | poison: -100 | immune_to_poison, immune_to_mind_control |
+| demon | DEM | fire: -50, radiant: 50, necrotic: -25 | resistant_to_fire |
+| ooze | OOZ | slashing: -50, piercing: -50, acid: -100 | immune_to_mind_control |
+| beast | BST | None | susceptible_to_animal_handling |
+| aberration | ABR | None | immune_to_mind_control |
+| monstrosity | MON | None | - |
+
+## Elemental Subtypes
+
+| Subtype | Resistances |
+|---------|-------------|
+| fire | fire: -100, ice: 100 |
+| ice | ice: -100, fire: 100 |
+| earth | piercing: -50, bludgeoning: -25 |
+| air | lightning: -25 |
+
+## Integration with ElementalSystem
+
+The `ElementalSystem.calculate_elemental_damage()` function uses CreatureTypeManager to:
+
+1. Get merged resistances for the target
+2. Check special rules for type-specific behaviors
+3. Apply type-level bonuses (e.g., radiant vs undead)
+
+```gdscript
+# In ElementalSystem.calculate_elemental_damage():
+var merged = CreatureTypeManager.get_merged_resistances(creature_type, element_subtype, creature_resistances)
+
+if CreatureTypeManager.has_special_rule(creature_type, "heals_from_necrotic"):
+    # Heal instead of damage
+```
+
+## Related Documentation
+
+- [Enemies Data](../data/enemies.md) - Enemy JSON format with creature_type
+- [Elemental System](./elemental-system.md) - Damage calculation
+- [Combat System](./combat-system.md) - Damage application

--- a/entities/enemy.gd
+++ b/entities/enemy.gd
@@ -83,6 +83,7 @@ static func create(enemy_data: Dictionary) -> Enemy:
 
 	# Creature type for elemental damage rules
 	enemy.creature_type = enemy_data.get("creature_type", "humanoid")
+	enemy.element_subtype = enemy_data.get("element_subtype", "")
 
 	# Elemental resistances
 	if enemy_data.has("elemental_resistances"):

--- a/entities/entity.gd
+++ b/entities/entity.gd
@@ -39,8 +39,9 @@ var is_alive: bool = true
 var base_damage: int = 1  # Unarmed/natural weapon damage
 var armor: int = 0  # Damage reduction
 
-# Creature type for mind control immunity (humanoid, animal, undead, construct)
+# Creature type for mind control immunity and damage resistances
 var creature_type: String = "humanoid"
+var element_subtype: String = ""  # Optional subtype (fire, ice, earth, air) for elementals
 var faction: String = "neutral"  # player, enemy, neutral, hostile_to_all
 var ai_state: String = "normal"  # normal, fleeing, berserk, idle
 

--- a/plans/features/ideas.md
+++ b/plans/features/ideas.md
@@ -3,7 +3,7 @@
 ## Version 1.2 Updates 
 ---
 
-[x] Test mode Expansion
+- [x] Test mode Expansion
     Implement the following improvements to the Debug Mode~~
     * For all the selection lists of hazards, spells, receipes, etc,  in the debug section, if the thing being listed has a level of some kind, sort by that first. Then sort alphabetically.
     * add options to spawn structures, crops, and resources
@@ -13,10 +13,14 @@
     Made flowers, herbs, and mushrooms collectable by walking over them. These are not collected if auto-pickup is off
 - [x] H for pickup
     When auto-pickup is turned off, standing on an item and pressing H (harvest) will pick up the item.
-- [ ] Creature Types
+- [x] Creature Types
     Classify all creature with types (goblinoid, undead, humanoid,beast,slime, etc.) Add these to the display in Debug mode for each creature in the list (for filtering). We previously implemented damage types & resistances at the creature level. Also add the ability to configure resistences at the creature type level. For example, all creatures of type Elemental - Fire should be immune to fire damage.
+- [ ] Resistance / Vulnerability cues
+    When a creature has immunity or resistance to an attack or action, the log should indicate a cue to the player, like "Your axe seems to do less damage that usual."
 ---
 ## Unplanned
+- [ ] Enemy abilities
+    Some creatures should have special abilities - trolls have regenreation, dragons breath fire, etc. Implement a system to support special abilities that can be defined through data configuration
 - [ ] Allow enemies to use ranged weapons and spells.
     Humanoid creatures should be able to use ranged weapons like bows and slings to attach players. Spell casting creatures (mages, demons, etc) should also be able to cast spells on players to hurt or hinder them. For instance, in addition to the combat spells, a wizard of sufficent level should be able to cast a Slow spell on the player that causes the player to only be able to act once every 2 turns until the spell ends or the player makes a successful save.
 - [ ] Creature interaction

--- a/project.godot
+++ b/project.godot
@@ -45,6 +45,7 @@ SpellManager="*res://autoload/spell_manager.gd"
 IdentificationManager="*res://autoload/identification_manager.gd"
 RitualManager="*res://autoload/ritual_manager.gd"
 SkillManager="*res://autoload/skill_manager.gd"
+CreatureTypeManager="*res://autoload/creature_type_manager.gd"
 
 [debug]
 

--- a/scripts/add_creature_types.py
+++ b/scripts/add_creature_types.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""
+Script to add creature_type field to all enemy JSON files based on folder structure.
+Also adds element_subtype for elemental creatures.
+"""
+
+import json
+import os
+from pathlib import Path
+
+# Base path for enemy data
+ENEMIES_PATH = Path(__file__).parent.parent / "data" / "enemies"
+
+# Mapping from folder name to creature_type
+FOLDER_TO_TYPE = {
+    "aberrations": "aberration",
+    "animals": "beast",
+    "beasts": "beast",
+    "constructs": "construct",
+    "demons": "demon",
+    "elementals": "elemental",
+    "humanoids": "humanoid",
+    "monstrosities": "monstrosity",
+    "oozes": "ooze",
+    "undead": "undead",
+}
+
+# Special handling for summons folder - map by ID pattern
+SUMMON_TYPE_MAPPING = {
+    "summoned_skeleton": "undead",
+    "summoned_wolf": "beast",
+}
+
+# Elemental subtypes based on enemy ID
+ELEMENTAL_SUBTYPES = {
+    "fire_elemental": "fire",
+    "ice_elemental": "ice",
+    "air_elemental": "air",
+    "earth_elemental": "earth",
+    "water_elemental": "water",
+}
+
+
+def process_enemy_file(file_path: Path, folder_name: str) -> bool:
+    """
+    Process a single enemy JSON file.
+    Returns True if the file was modified, False otherwise.
+    """
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, IOError) as e:
+        print(f"  ERROR reading {file_path}: {e}")
+        return False
+
+    modified = False
+    enemy_id = data.get("id", "")
+
+    # Determine creature_type
+    if folder_name == "summons":
+        creature_type = SUMMON_TYPE_MAPPING.get(enemy_id, "humanoid")
+    else:
+        creature_type = FOLDER_TO_TYPE.get(folder_name, "humanoid")
+
+    # Add or update creature_type if needed
+    if data.get("creature_type") != creature_type:
+        data["creature_type"] = creature_type
+        modified = True
+        print(f"  + Set creature_type: {creature_type}")
+
+    # Add element_subtype for elementals
+    if creature_type == "elemental" and enemy_id in ELEMENTAL_SUBTYPES:
+        element_subtype = ELEMENTAL_SUBTYPES[enemy_id]
+        if data.get("element_subtype") != element_subtype:
+            data["element_subtype"] = element_subtype
+            modified = True
+            print(f"  + Set element_subtype: {element_subtype}")
+
+    # Write back if modified
+    if modified:
+        # Reorder keys to put creature_type and element_subtype after ascii_color
+        ordered_data = reorder_keys(data)
+        with open(file_path, 'w', encoding='utf-8') as f:
+            json.dump(ordered_data, f, indent=2)
+            f.write('\n')  # Add trailing newline
+
+    return modified
+
+
+def reorder_keys(data: dict) -> dict:
+    """
+    Reorder dictionary keys to place creature_type and element_subtype
+    in a logical position (after ascii_color, before stats).
+    """
+    # Define the preferred key order
+    preferred_order = [
+        "id",
+        "name",
+        "description",
+        "cr",
+        "ascii_char",
+        "ascii_color",
+        "creature_type",
+        "element_subtype",
+        "stats",
+        "attributes",
+        "base_health",
+        "base_damage",
+        "armor",
+        "elemental_resistances",
+        "yields",
+        "behavior",
+        "faction",
+        "loot_table",
+        "xp_value",
+        "spawn_biomes",
+        "spawn_dungeons",
+        "spawn_density_overworld",
+        "spawn_density_dungeon",
+        "min_spawn_level",
+        "max_spawn_level",
+        "feared_components",
+        "fear_distance",
+        "summon_only",
+        "abilities",
+        "spellcaster",
+    ]
+
+    # Build ordered dictionary
+    ordered = {}
+    for key in preferred_order:
+        if key in data:
+            ordered[key] = data[key]
+
+    # Add any remaining keys not in preferred order
+    for key in data:
+        if key not in ordered:
+            ordered[key] = data[key]
+
+    return ordered
+
+
+def main():
+    print(f"Processing enemy files in: {ENEMIES_PATH}")
+    print("-" * 60)
+
+    total_files = 0
+    modified_files = 0
+
+    # Process each folder
+    for folder in sorted(ENEMIES_PATH.iterdir()):
+        if not folder.is_dir():
+            continue
+
+        folder_name = folder.name
+        print(f"\nFolder: {folder_name}")
+
+        # Process each JSON file in the folder
+        for json_file in sorted(folder.glob("*.json")):
+            total_files += 1
+            print(f"  Processing: {json_file.name}")
+
+            if process_enemy_file(json_file, folder_name):
+                modified_files += 1
+
+    print("\n" + "-" * 60)
+    print(f"Total files processed: {total_files}")
+    print(f"Files modified: {modified_files}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Introduced `creature_type` and `element_subtype` fields in enemy JSON files for better classification and resistance handling.
- Created `CreatureTypeManager` to manage creature type definitions and resistances loaded from JSON.
- Updated enemy definitions for wraith and zombie to include `creature_type`.
- Enhanced elemental damage calculations to consider creature types and their resistances.
- Added new creature types: aberration, beast, construct, demon, elemental, humanoid, monstrosity, ooze, undead.
- Implemented a script to automatically add `creature_type` and `element_subtype` to existing enemy JSON files based on folder structure.
- Updated documentation to reflect changes in creature types and their resistances.