### PR TITLE
feat: Auto-harvest when bumping into harvestable with right tool

### DIFF
--- a/plans/features/v1.3/ideas.md
+++ b/plans/features/v1.3/ideas.md
@@ -8,7 +8,7 @@
     Daytime should last longer than night. 
 - [ ] Feature: Sprint
     The player may invoke a "Sprint" mode, which allows the player to move (and only move) twice before creatures take their turn. Taking any action other than moving turns off sprint mode. Sprint mode on/off should be shown in the bottom of the UI. Moving in sprint mode drains stamina at 4x the normal rate. make sure to add the sprint mode toggle key to the help screen
-- [ ] Feature: Default Harvest Interaction
+- [x] Feature: Default Harvest Interaction
     If the player runs into a harvestable item and has an appropriate item to harvest it equipped (e.g. Axe for a tree) OR has the required item in inventory (like filling a waterskin) turn on auto harvest and start the harvesting process.
 - [x] Content: Increase Overworld Creature Count
     There is a very low frequency of game animals and enemies in the overworld. Increase these.


### PR DESCRIPTION
When player moves into a harvestable tile (tree, rock, water, etc.) and has the appropriate tool equipped or in inventory, the game now automatically starts harvesting instead of just showing a blocked message.

This applies to any harvestable resource where the player meets the tool requirements (e.g., axe for tree, pickaxe for rock, waterskin for water).

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>