### PR TITLE
feat: Revamp loot tables to include specific gem types and enhance treasure diversity

### DIFF
--- a/autoload/item_manager.gd
+++ b/autoload/item_manager.gd
@@ -158,24 +158,26 @@ func create_item(item_id: String, count: int = 1) -> Item:
 
 ## Create multiple item stacks if needed
 ## Returns array of items to handle counts larger than max_stack
+## Supports both legacy item IDs and template-based items (e.g., "quartz_gem")
 func create_item_stacks(item_id: String, total_count: int) -> Array[Item]:
 	var items: Array[Item] = []
-	
-	if not has_item(item_id):
+	var remaining = total_count
+
+	# Get item data - supports both legacy and template-based items
+	var data = get_item_data(item_id)
+	if data.is_empty():
 		push_error("ItemManager: Unknown item ID: %s" % item_id)
 		return items
-	
-	var remaining = total_count
-	var data = _item_data[item_id]
+
 	var max_stack = data.get("max_stack", 1)
-	
+
 	while remaining > 0:
 		var stack_count = min(remaining, max_stack)
 		var item = create_item(item_id, stack_count)
 		if item:
 			items.append(item)
 		remaining -= stack_count
-	
+
 	return items
 
 ## Get all item IDs of a specific type

--- a/data/classes/cleric.json
+++ b/data/classes/cleric.json
@@ -33,11 +33,29 @@
         "heal_amount": 10,
         "activation_message": "Blessed Rest! Divine energy restores your vitality."
       }
+    },
+    {
+      "id": "turn_undead",
+      "name": "Turn Undead",
+      "description": "Channel divine power to damage and terrify nearby undead. Radius 3 (+1 per 4 levels).",
+      "type": "active",
+      "uses_per_day": 2,
+      "activation_pattern": "aoe_undead_effect",
+      "effect": {
+        "base_damage": 12,
+        "damage_type": "radiant",
+        "fear_duration": 5,
+        "base_radius": 3,
+        "radius_per_levels": 4,
+        "target_creature_type": "undead",
+        "activation_message": "You channel divine light! Undead creatures recoil in terror!"
+      }
     }
   ],
   "restrictions": {},
   "starting_equipment": [
     {"item_id": "iron_mace", "count": 1},
     {"item_id": "bandage", "count": 3}
-  ]
+  ],
+  "starting_spells": ["light", "heal_minor", "sacred_flame"]
 }

--- a/data/item_templates/misc/gem.json
+++ b/data/item_templates/misc/gem.json
@@ -1,0 +1,27 @@
+{
+  "template_id": "gem",
+  "display_name": "Gem",
+  "description_base": "A precious gemstone that sparkles in the light.",
+  "category": "misc",
+  "subtype": "treasure",
+  "base_properties": {
+    "ascii_char": "*",
+    "flags": {
+      "equippable": false,
+      "consumable": false,
+      "craftable": false,
+      "tool": false,
+      "valuable": true
+    },
+    "max_stack": 10
+  },
+  "base_stats": {
+    "weight": 0.1,
+    "value": 50
+  },
+  "applicable_variants": ["gem_type"],
+  "default_variants": {
+    "gem_type": "quartz"
+  },
+  "required_variants": ["gem_type"]
+}

--- a/data/items/armor/cursed_ring.json
+++ b/data/items/armor/cursed_ring.json
@@ -6,7 +6,7 @@
 	"color": "#4B0082",
 	"weight": 0.1,
 	"value": 150,
-	"stack_size": 1,
+	"max_stack": 1,
 	"item_type": "armor",
 	"slot": "accessory"
 }

--- a/data/items/consumables/potions/antidote.json
+++ b/data/items/consumables/potions/antidote.json
@@ -12,7 +12,7 @@
   },
   "weight": 0.2,
   "value": 25,
-  "stack_size": 5,
+  "max_stack": 5,
   "ascii_char": "!",
   "ascii_color": "#00FF00",
   "unidentified": true

--- a/data/items/materials/crystal_ball.json
+++ b/data/items/materials/crystal_ball.json
@@ -6,7 +6,7 @@
   "subtype": "ritual_component",
   "weight": 2.0,
   "value": 250,
-  "stack_size": 1,
+  "max_stack": 1,
   "ascii_char": "o",
   "color": "#88DDFF",
   "rarity": "rare"

--- a/data/items/materials/obsidian.json
+++ b/data/items/materials/obsidian.json
@@ -6,7 +6,7 @@
   "subtype": "ritual_component",
   "weight": 0.5,
   "value": 25,
-  "stack_size": 50,
+  "max_stack": 50,
   "ascii_char": "*",
   "color": "#333344",
   "rarity": "uncommon"

--- a/data/items/materials/rat_tail.json
+++ b/data/items/materials/rat_tail.json
@@ -6,6 +6,6 @@
 	"color": "#808080",
 	"weight": 0.05,
 	"value": 2,
-	"stack_size": 20,
+	"max_stack": 20,
 	"item_type": "material"
 }

--- a/data/items/materials/tattered_cloth.json
+++ b/data/items/materials/tattered_cloth.json
@@ -6,6 +6,6 @@
 	"color": "#A9A9A9",
 	"weight": 0.1,
 	"value": 1,
-	"stack_size": 20,
+	"max_stack": 20,
 	"item_type": "material"
 }

--- a/data/items/materials/wolf_pelt.json
+++ b/data/items/materials/wolf_pelt.json
@@ -6,6 +6,6 @@
 	"color": "#696969",
 	"weight": 2.0,
 	"value": 25,
-	"stack_size": 5,
+	"max_stack": 5,
 	"item_type": "material"
 }

--- a/data/items/misc/ancient_artifact.json
+++ b/data/items/misc/ancient_artifact.json
@@ -6,6 +6,6 @@
 	"color": "#FFD700",
 	"weight": 0.5,
 	"value": 100,
-	"stack_size": 1,
+	"max_stack": 1,
 	"item_type": "misc"
 }

--- a/data/items/misc/ancient_crown.json
+++ b/data/items/misc/ancient_crown.json
@@ -6,6 +6,6 @@
 	"color": "#FFD700",
 	"weight": 1.0,
 	"value": 500,
-	"stack_size": 1,
+	"max_stack": 1,
 	"item_type": "misc"
 }

--- a/data/items/misc/ancient_scroll.json
+++ b/data/items/misc/ancient_scroll.json
@@ -6,6 +6,6 @@
 	"color": "#DEB887",
 	"weight": 0.1,
 	"value": 75,
-	"stack_size": 5,
+	"max_stack": 5,
 	"item_type": "misc"
 }

--- a/data/items/misc/gem.json
+++ b/data/items/misc/gem.json
@@ -6,6 +6,6 @@
 	"color": "#00CED1",
 	"weight": 0.1,
 	"value": 50,
-	"stack_size": 10,
+	"max_stack": 10,
 	"item_type": "misc"
 }

--- a/data/items/misc/soul_gem.json
+++ b/data/items/misc/soul_gem.json
@@ -6,6 +6,6 @@
 	"color": "#8B008B",
 	"weight": 0.2,
 	"value": 200,
-	"stack_size": 5,
+	"max_stack": 5,
 	"item_type": "misc"
 }

--- a/data/items/weapons/cursed_blade.json
+++ b/data/items/weapons/cursed_blade.json
@@ -6,7 +6,7 @@
 	"color": "#4B0082",
 	"weight": 3.0,
 	"value": 300,
-	"stack_size": 1,
+	"max_stack": 1,
 	"item_type": "weapon",
 	"slot": "main_hand",
 	"damage": 12,

--- a/data/items/weapons/rusty_sword.json
+++ b/data/items/weapons/rusty_sword.json
@@ -6,7 +6,7 @@
 	"color": "#8B4513",
 	"weight": 2.5,
 	"value": 10,
-	"stack_size": 1,
+	"max_stack": 1,
 	"item_type": "weapon",
 	"slot": "main_hand",
 	"damage": 4,

--- a/data/loot_tables/aberration_common.json
+++ b/data/loot_tables/aberration_common.json
@@ -3,7 +3,9 @@
 	"name": "Aberration Common Loot",
 	"description": "Strange items from aberrant beings. Their alien nature sometimes crystallizes into valuable gems.",
 	"drops": [
-		{"item_id": "gem", "min_count": 1, "max_count": 2, "chance": 0.25, "cr_scales": true},
+		{"item_id": "amethyst_gem", "min_count": 1, "max_count": 1, "chance": 0.12, "cr_scales": true},
+		{"item_id": "sapphire_gem", "min_count": 1, "max_count": 1, "chance": 0.08, "cr_scales": true},
+		{"item_id": "emerald_gem", "min_count": 1, "max_count": 1, "chance": 0.05, "cr_scales": true},
 		{"item_id": "soul_gem", "min_count": 1, "max_count": 1, "chance": 0.1, "cr_scales": true},
 		{"item_id": "scroll_identify", "min_count": 1, "max_count": 1, "chance": 0.08}
 	]

--- a/data/loot_tables/ancient_treasure.json
+++ b/data/loot_tables/ancient_treasure.json
@@ -7,7 +7,10 @@
 	],
 	"drops": [
 		{"item_id": "ancient_artifact", "min_count": 1, "max_count": 1, "chance": 0.3},
-		{"item_id": "gem", "min_count": 1, "max_count": 2, "chance": 0.4, "cr_scales": true},
+		{"item_id": "garnet_gem", "min_count": 1, "max_count": 2, "chance": 0.2, "cr_scales": true},
+		{"item_id": "sapphire_gem", "min_count": 1, "max_count": 1, "chance": 0.12, "cr_scales": true},
+		{"item_id": "emerald_gem", "min_count": 1, "max_count": 1, "chance": 0.08, "cr_scales": true},
+		{"item_id": "ruby_gem", "min_count": 1, "max_count": 1, "chance": 0.04, "cr_scales": true},
 		{"item_id": "ancient_scroll", "min_count": 1, "max_count": 1, "chance": 0.2},
 		{"item_id": "cursed_ring", "min_count": 1, "max_count": 1, "chance": 0.1},
 		{"item_id": "healing_potion", "min_count": 1, "max_count": 2, "chance": 0.25},

--- a/data/loot_tables/construct_common.json
+++ b/data/loot_tables/construct_common.json
@@ -3,7 +3,9 @@
 	"name": "Construct Common Loot",
 	"description": "Drops from magical constructs. May contain animating gems or metal components.",
 	"drops": [
-		{"item_id": "gem", "min_count": 1, "max_count": 2, "chance": 0.4, "cr_scales": true},
+		{"item_id": "amethyst_gem", "min_count": 1, "max_count": 1, "chance": 0.2, "cr_scales": true},
+		{"item_id": "topaz_gem", "min_count": 1, "max_count": 1, "chance": 0.12, "cr_scales": true},
+		{"item_id": "sapphire_gem", "min_count": 1, "max_count": 1, "chance": 0.08, "cr_scales": true},
 		{"item_id": "iron_ingot", "min_count": 1, "max_count": 2, "chance": 0.3},
 		{"item_id": "steel_ingot", "min_count": 1, "max_count": 1, "chance": 0.15},
 		{"item_id": "soul_gem", "min_count": 1, "max_count": 1, "chance": 0.08, "cr_scales": true}

--- a/data/loot_tables/cr_11_16_treasure.json
+++ b/data/loot_tables/cr_11_16_treasure.json
@@ -4,7 +4,11 @@
 	"description": "Valuable treasure for CR 11-16 creatures. Large gold amounts, rare gems, scrolls, magic items.",
 	"drops": [
 		{"item_id": "gold_coin", "min_count": 50, "max_count": 200, "chance": 0.8, "cr_scales": true},
-		{"item_id": "gem", "min_count": 2, "max_count": 5, "chance": 0.4, "cr_scales": true},
+		{"item_id": "garnet_gem", "min_count": 1, "max_count": 2, "chance": 0.2, "cr_scales": true},
+		{"item_id": "sapphire_gem", "min_count": 1, "max_count": 2, "chance": 0.15, "cr_scales": true},
+		{"item_id": "emerald_gem", "min_count": 1, "max_count": 1, "chance": 0.1, "cr_scales": true},
+		{"item_id": "ruby_gem", "min_count": 1, "max_count": 1, "chance": 0.06, "cr_scales": true},
+		{"item_id": "diamond_gem", "min_count": 1, "max_count": 1, "chance": 0.02, "cr_scales": true},
 		{"item_id": "soul_gem", "min_count": 1, "max_count": 1, "chance": 0.15, "cr_scales": true},
 		{"item_id": "healing_potion", "min_count": 1, "max_count": 2, "chance": 0.25},
 		{"item_id": "mana_potion", "min_count": 1, "max_count": 2, "chance": 0.2},

--- a/data/loot_tables/cr_17_plus_treasure.json
+++ b/data/loot_tables/cr_17_plus_treasure.json
@@ -6,7 +6,10 @@
 		{"item_id": "gold_coin", "min_count": 100, "max_count": 500, "cr_scales": true}
 	],
 	"drops": [
-		{"item_id": "gem", "min_count": 3, "max_count": 10, "chance": 0.7, "cr_scales": true},
+		{"item_id": "sapphire_gem", "min_count": 1, "max_count": 3, "chance": 0.4, "cr_scales": true},
+		{"item_id": "emerald_gem", "min_count": 1, "max_count": 2, "chance": 0.35, "cr_scales": true},
+		{"item_id": "ruby_gem", "min_count": 1, "max_count": 2, "chance": 0.25, "cr_scales": true},
+		{"item_id": "diamond_gem", "min_count": 1, "max_count": 1, "chance": 0.15, "cr_scales": true},
 		{"item_id": "soul_gem", "min_count": 1, "max_count": 3, "chance": 0.4, "cr_scales": true},
 		{"item_id": "ancient_artifact", "min_count": 1, "max_count": 1, "chance": 0.2},
 		{"item_id": "ancient_crown", "min_count": 1, "max_count": 1, "chance": 0.1},

--- a/data/loot_tables/cr_5_10_treasure.json
+++ b/data/loot_tables/cr_5_10_treasure.json
@@ -4,7 +4,10 @@
 	"description": "Moderate treasure for CR 5-10 creatures. Gold coins, uncommon gems, potions.",
 	"drops": [
 		{"item_id": "gold_coin", "min_count": 10, "max_count": 50, "chance": 0.6, "cr_scales": true},
-		{"item_id": "gem", "min_count": 1, "max_count": 2, "chance": 0.2, "cr_scales": true},
+		{"item_id": "amethyst_gem", "min_count": 1, "max_count": 2, "chance": 0.12, "cr_scales": true},
+		{"item_id": "topaz_gem", "min_count": 1, "max_count": 1, "chance": 0.08, "cr_scales": true},
+		{"item_id": "garnet_gem", "min_count": 1, "max_count": 1, "chance": 0.06, "cr_scales": true},
+		{"item_id": "sapphire_gem", "min_count": 1, "max_count": 1, "chance": 0.03, "cr_scales": true},
 		{"item_id": "healing_potion", "min_count": 1, "max_count": 1, "chance": 0.15},
 		{"item_id": "mana_potion", "min_count": 1, "max_count": 1, "chance": 0.1},
 		{"item_id": "antidote", "min_count": 1, "max_count": 1, "chance": 0.1},

--- a/data/loot_tables/demon_common.json
+++ b/data/loot_tables/demon_common.json
@@ -4,7 +4,9 @@
 	"description": "Drops from demonic entities. May contain soul gems and precious gems from their dark dealings.",
 	"drops": [
 		{"item_id": "soul_gem", "min_count": 1, "max_count": 2, "chance": 0.4, "cr_scales": true},
-		{"item_id": "gem", "min_count": 1, "max_count": 3, "chance": 0.35, "cr_scales": true},
+		{"item_id": "garnet_gem", "min_count": 1, "max_count": 2, "chance": 0.18, "cr_scales": true},
+		{"item_id": "ruby_gem", "min_count": 1, "max_count": 1, "chance": 0.12, "cr_scales": true},
+		{"item_id": "diamond_gem", "min_count": 1, "max_count": 1, "chance": 0.05, "cr_scales": true},
 		{"item_id": "gold_coin", "min_count": 10, "max_count": 50, "chance": 0.5, "cr_scales": true},
 		{"item_id": "scroll_curse", "min_count": 1, "max_count": 1, "chance": 0.15}
 	]

--- a/data/loot_tables/elemental_common.json
+++ b/data/loot_tables/elemental_common.json
@@ -3,7 +3,10 @@
 	"name": "Elemental Common Loot",
 	"description": "Drops from elemental creatures. Their essence sometimes crystallizes into gems.",
 	"drops": [
-		{"item_id": "gem", "min_count": 1, "max_count": 3, "chance": 0.5, "cr_scales": true},
+		{"item_id": "quartz_gem", "min_count": 1, "max_count": 2, "chance": 0.25, "cr_scales": true},
+		{"item_id": "amethyst_gem", "min_count": 1, "max_count": 1, "chance": 0.15, "cr_scales": true},
+		{"item_id": "topaz_gem", "min_count": 1, "max_count": 1, "chance": 0.1, "cr_scales": true},
+		{"item_id": "sapphire_gem", "min_count": 1, "max_count": 1, "chance": 0.05, "cr_scales": true},
 		{"item_id": "soul_gem", "min_count": 1, "max_count": 1, "chance": 0.1, "cr_scales": true}
 	]
 }

--- a/data/loot_tables/humanoid_common.json
+++ b/data/loot_tables/humanoid_common.json
@@ -12,6 +12,8 @@
 		{"item_id": "healing_potion", "min_count": 1, "max_count": 1, "chance": 0.08},
 		{"item_id": "lockpick", "min_count": 1, "max_count": 1, "chance": 0.04},
 		{"item_id": "rope", "min_count": 1, "max_count": 1, "chance": 0.1},
-		{"item_id": "gem", "min_count": 1, "max_count": 1, "chance": 0.03, "cr_scales": true}
+		{"item_id": "quartz_gem", "min_count": 1, "max_count": 1, "chance": 0.02, "cr_scales": true},
+		{"item_id": "amethyst_gem", "min_count": 1, "max_count": 1, "chance": 0.008, "cr_scales": true},
+		{"item_id": "topaz_gem", "min_count": 1, "max_count": 1, "chance": 0.005, "cr_scales": true}
 	]
 }

--- a/data/loot_tables/humanoid_mage.json
+++ b/data/loot_tables/humanoid_mage.json
@@ -10,7 +10,9 @@
 		{"item_id": "scroll_heal", "min_count": 1, "max_count": 1, "chance": 0.1},
 		{"item_id": "scroll_shield", "min_count": 1, "max_count": 1, "chance": 0.08},
 		{"item_id": "scroll_flame_bolt", "min_count": 1, "max_count": 1, "chance": 0.06},
-		{"item_id": "gem", "min_count": 1, "max_count": 2, "chance": 0.15, "cr_scales": true},
+		{"item_id": "amethyst_gem", "min_count": 1, "max_count": 1, "chance": 0.08, "cr_scales": true},
+		{"item_id": "sapphire_gem", "min_count": 1, "max_count": 1, "chance": 0.05, "cr_scales": true},
+		{"item_id": "ruby_gem", "min_count": 1, "max_count": 1, "chance": 0.02, "cr_scales": true},
 		{"item_id": "soul_gem", "min_count": 1, "max_count": 1, "chance": 0.05}
 	]
 }

--- a/data/loot_tables/monstrosity_common.json
+++ b/data/loot_tables/monstrosity_common.json
@@ -6,7 +6,8 @@
 		{"item_id": "bone", "min_count": 1, "max_count": 3, "chance": 0.5},
 		{"item_id": "leather", "min_count": 1, "max_count": 2, "chance": 0.3},
 		{"item_id": "gold_coin", "min_count": 1, "max_count": 15, "chance": 0.25, "cr_scales": true},
-		{"item_id": "gem", "min_count": 1, "max_count": 1, "chance": 0.1, "cr_scales": true},
+		{"item_id": "quartz_gem", "min_count": 1, "max_count": 1, "chance": 0.06, "cr_scales": true},
+		{"item_id": "garnet_gem", "min_count": 1, "max_count": 1, "chance": 0.03, "cr_scales": true},
 		{"item_id": "raw_meat", "min_count": 1, "max_count": 2, "chance": 0.4}
 	]
 }

--- a/data/loot_tables/ooze_common.json
+++ b/data/loot_tables/ooze_common.json
@@ -4,7 +4,8 @@
 	"description": "Items recovered from ooze remains. Contains swallowed treasures that survived digestion.",
 	"drops": [
 		{"item_id": "gold_coin", "min_count": 1, "max_count": 20, "chance": 0.4, "cr_scales": true},
-		{"item_id": "gem", "min_count": 1, "max_count": 1, "chance": 0.15, "cr_scales": true},
+		{"item_id": "quartz_gem", "min_count": 1, "max_count": 1, "chance": 0.1, "cr_scales": true},
+		{"item_id": "amethyst_gem", "min_count": 1, "max_count": 1, "chance": 0.04, "cr_scales": true},
 		{"item_id": "bone", "min_count": 1, "max_count": 3, "chance": 0.6},
 		{"item_id": "iron_key", "min_count": 1, "max_count": 1, "chance": 0.08}
 	]

--- a/data/loot_tables/undead_boss.json
+++ b/data/loot_tables/undead_boss.json
@@ -8,7 +8,10 @@
 	"drops": [
 		{"item_id": "ancient_crown", "min_count": 1, "max_count": 1, "chance": 0.5},
 		{"item_id": "soul_gem", "min_count": 1, "max_count": 2, "chance": 0.3, "cr_scales": true},
-		{"item_id": "gem", "min_count": 1, "max_count": 3, "chance": 0.4, "cr_scales": true},
+		{"item_id": "sapphire_gem", "min_count": 1, "max_count": 2, "chance": 0.25, "cr_scales": true},
+		{"item_id": "emerald_gem", "min_count": 1, "max_count": 1, "chance": 0.15, "cr_scales": true},
+		{"item_id": "ruby_gem", "min_count": 1, "max_count": 1, "chance": 0.08, "cr_scales": true},
+		{"item_id": "diamond_gem", "min_count": 1, "max_count": 1, "chance": 0.03, "cr_scales": true},
 		{"item_id": "bone", "min_count": 3, "max_count": 8, "chance": 1.0},
 		{"item_id": "ancient_artifact", "min_count": 1, "max_count": 1, "chance": 0.35}
 	]

--- a/data/resources/rock.json
+++ b/data/resources/rock.json
@@ -10,7 +10,9 @@
   "harvest_actions": 3,
   "yields": [
     {"item_id": "stone", "min_count": 3, "max_count": 6},
-    {"item_id": "flint", "min_count": 0, "max_count": 2, "chance": 0.3}
+    {"item_id": "flint", "min_count": 0, "max_count": 2, "chance": 0.3},
+    {"item_id": "sling_stone", "min_count": 2, "max_count": 10, "chance": 0.2}
+ 
   ],
   "replacement_tile": "floor",
   "harvest_message": "Broke rock with %tool%, got %yield%",

--- a/data/spells/cantrips/minor_healing.json
+++ b/data/spells/cantrips/minor_healing.json
@@ -1,0 +1,27 @@
+{
+  "id": "minor_healing",
+  "name": "Minor Healing",
+  "description": "Restore a small amount of health to yourself.",
+  "school": "conjuration",
+  "level": 0,
+  "mana_cost": 8,
+  "requirements": {
+    "character_level": 1,
+    "intelligence": 8
+  },
+  "targeting": {
+    "mode": "self"
+  },
+  "effects": {
+    "heal": {
+      "base": 2,
+      "scaling": 4
+    }
+  },
+  "duration": {
+    "type": "instant"
+  },
+  "cast_message": "Healing energy flows through you!",
+  "ascii_char": "+",
+  "ascii_color": "#44FF44"
+}

--- a/data/spells/cantrips/sacred_flame.json
+++ b/data/spells/cantrips/sacred_flame.json
@@ -1,0 +1,30 @@
+{
+  "id": "sacred_flame",
+  "name": "Sacred Flame",
+  "description": "A beam of radiant energy streaks toward a target, especially effective against undead.",
+  "school": "evocation",
+  "level": 0,
+  "mana_cost": 5,
+  "requirements": {
+    "character_level": 0,
+    "intelligence": 8
+  },
+  "targeting": {
+    "mode": "ranged",
+    "range": 6,
+    "requires_los": true
+  },
+  "effects": {
+    "damage": {
+      "type": "radiant",
+      "base": 4,
+      "scaling": 0
+    }
+  },
+  "duration": {
+    "type": "instant"
+  },
+  "cast_message": "You invoke sacred flame!",
+  "ascii_char": "*",
+  "ascii_color": "#FFD700"
+}

--- a/data/variants/gem_type.json
+++ b/data/variants/gem_type.json
@@ -1,0 +1,101 @@
+{
+  "variant_type": "gem_type",
+  "variants": {
+    "quartz": {
+      "name_prefix": "",
+      "name_override": "Quartz",
+      "description_modifier": "a common clear crystal",
+      "modifiers": {
+        "value": {"type": "multiply", "value": 0.5}
+      },
+      "overrides": {
+        "ascii_color": "#E0E0E0"
+      },
+      "tier": 1
+    },
+    "amethyst": {
+      "name_prefix": "",
+      "name_override": "Amethyst",
+      "description_modifier": "a purple gemstone prized for its clarity",
+      "modifiers": {
+        "value": {"type": "multiply", "value": 1.0}
+      },
+      "overrides": {
+        "ascii_color": "#9966CC"
+      },
+      "tier": 2
+    },
+    "topaz": {
+      "name_prefix": "",
+      "name_override": "Topaz",
+      "description_modifier": "a golden-yellow gemstone",
+      "modifiers": {
+        "value": {"type": "multiply", "value": 1.2}
+      },
+      "overrides": {
+        "ascii_color": "#FFC87C"
+      },
+      "tier": 2
+    },
+    "garnet": {
+      "name_prefix": "",
+      "name_override": "Garnet",
+      "description_modifier": "a deep red gemstone",
+      "modifiers": {
+        "value": {"type": "multiply", "value": 1.5}
+      },
+      "overrides": {
+        "ascii_color": "#8B0000"
+      },
+      "tier": 2
+    },
+    "sapphire": {
+      "name_prefix": "",
+      "name_override": "Sapphire",
+      "description_modifier": "a brilliant blue gemstone of great beauty",
+      "modifiers": {
+        "value": {"type": "multiply", "value": 2.5}
+      },
+      "overrides": {
+        "ascii_color": "#0F52BA"
+      },
+      "tier": 3
+    },
+    "emerald": {
+      "name_prefix": "",
+      "name_override": "Emerald",
+      "description_modifier": "a vivid green gemstone of exceptional quality",
+      "modifiers": {
+        "value": {"type": "multiply", "value": 3.0}
+      },
+      "overrides": {
+        "ascii_color": "#50C878"
+      },
+      "tier": 3
+    },
+    "ruby": {
+      "name_prefix": "",
+      "name_override": "Ruby",
+      "description_modifier": "a fiery red gemstone of legendary value",
+      "modifiers": {
+        "value": {"type": "multiply", "value": 4.0}
+      },
+      "overrides": {
+        "ascii_color": "#E0115F"
+      },
+      "tier": 4
+    },
+    "diamond": {
+      "name_prefix": "",
+      "name_override": "Diamond",
+      "description_modifier": "the most precious of all gemstones, perfectly clear",
+      "modifiers": {
+        "value": {"type": "multiply", "value": 6.0}
+      },
+      "overrides": {
+        "ascii_color": "#B9F2FF"
+      },
+      "tier": 5
+    }
+  }
+}

--- a/entities/enemy.gd
+++ b/entities/enemy.gd
@@ -154,11 +154,25 @@ func take_turn() -> void:
 
 ## Execute AI behavior
 func _execute_behavior(player: Player) -> void:
-	# First, check if we should attack (player is adjacent)
+	# First, check if fleeing due to fear effect (spell-based fear like Turn Undead)
+	if ai_state == "fleeing":
+		var fear_effect = get_active_effect("turn_undead_fear")
+		if fear_effect.is_empty():
+			fear_effect = get_active_effect("fear_effect")
+
+		if not fear_effect.is_empty():
+			var flee_from = fear_effect.get("flee_from", player.position)
+			_move_away_from(flee_from)
+			return  # Fleeing consumes the turn
+		else:
+			# Fear effect expired but ai_state not reset - reset it
+			ai_state = "normal"
+
+	# Second, check if we should attack (player is adjacent)
 	if _attempt_attack_if_adjacent():
 		return  # Attack consumes the turn
 
-	# Check for feared components - flee if near any
+	# Check for feared components - flee if near any (environmental fear)
 	if not feared_components.is_empty() and _is_near_feared_component():
 		var threat_pos = _get_nearest_feared_component_position()
 		_move_away_from(threat_pos)

--- a/entities/player.gd
+++ b/entities/player.gd
@@ -1055,6 +1055,14 @@ func pickup_item(ground_item: GroundItem) -> bool:
 
 	var item = ground_item.item
 
+	# Handle gold coins specially - add directly to gold count
+	if item.id == "gold_coin":
+		var count = item.stack_size
+		gold += count
+		EventBus.message_logged.emit("Found %d gold!" % count)
+		EventBus.item_picked_up.emit(item)
+		return true
+
 	# Auto-equip lit light sources to off-hand if available
 	if item.provides_light and item.is_lit and item.can_equip_to_slot("off_hand"):
 		var off_hand = inventory.get_equipped("off_hand")

--- a/plans/features/ideas.md
+++ b/plans/features/ideas.md
@@ -6,10 +6,14 @@
 ---
 ## Unplanned
 
-- [ ] Save transportability
-    Add the ability to download a saved game as a JSON file and load it into a different instance of the game
+- [ ] Feature: Dungeon Map 
+      Opening the Map in a dungeone should show currently explored level
+- [ ] Save / Load Across Machines
+    Add the ability to download a saved game as a JSON file and load it into a different instance of the game. Add a Load from file option and a place to download a saved game to a file.
 - [ ] Feature: Initial Spawn Time - Day
     Start the player's first turn at the beginning of Day, not Dawn.
+- [ ] Bash / Hack Down Doors
+    Without a key or lockpicks, there is no way to open a locked door. Add the ability to bash/hack a door open (takes several turns, fewer the stronger the character is)
 - [ ] Feature: Tree Variety
     Support different kinds of trees (e.g. oak, yew, maple, alder, pine, fir, apple, cherry, pear, willow, magnolia, mangrove, olive, almond, spruce) The types of trees should vary by biome / elevation. Use the variant mechanic to define tree types. Trees should grow in clusters - but the occasional other tree may grow in a group. Some trees bear fruit. The fruit should be harvestable as a renewable resource seasonally. Some trees are also flowering (magnolia) and flowers should be harvestable like fruit. The player should still have the option to cut down the tree and receive wood of the tree type.
 - [ ] Weapon and Armor Proficiency

--- a/plans/features/v1.4/ideas.md
+++ b/plans/features/v1.4/ideas.md
@@ -1,7 +1,16 @@
 ## Version 1.4 Updates 
 ---
-- [X] Scaled Loot Drops
-    Loot drops shoulds be based on the scale of the creature. Review https://dungeonmastertools.github.io/treasure.html and the related pages to improve how loot tables work to make them more realistic. Consider having separate loot tables by type/CR instead of creature, and have each creature have a list of loot_tables instead of one.
+- [X] Feature: Scaled Loot Drops
+    Loot drops shoulds be based on the scale of the creature. Improve how loot tables work to make them more realistic. Having separate loot tables by type/CR instead of creature, and have each creature have a list of loot_tables instead of one.
 - [X] Bug: Overworld Features spawn on top of walls
-- [ ] Feature: Turn Undead
+- [X] Feature: Improved Combat Messaging
+- [X] Feature: Turn Undead
     Turn undead ability for cleric class, using traditional roguelike patterns
+- [X] UI/UX: Show spell targets with reticule
+    When as spell is selected and the option to tab through enemies appears, the selected enemy should show as targeted so the player knows which creature they are casting it on
+- [ ] Feature: Cleric Spell Casting
+    Clerics should not need a spellbook to cast spells. Instead, they should be able to case any spell they know as long as they possess a magical focus, a token of their faith. Give the cleric this object at creation.
+- [ ] Feature: Class Specific Spells
+    Some spells should be class specific (only clerics can cast, or only mages can cast) However, "Adventurers" should be able to cast any spell (with the appropriate magic focus or spellbook)
+     
+        

--- a/scenes/game.gd
+++ b/scenes/game.gd
@@ -1457,6 +1457,12 @@ func update_look_highlight(look_pos: Vector2i) -> void:
 			renderer.clear_highlight()
 
 
+## Hide targeting UI and clear highlight when targeting ends
+func hide_targeting_ui() -> void:
+	if renderer:
+		renderer.clear_highlight()
+
+
 ## Get ordinal suffix for a day number (1st, 2nd, 3rd, etc.)
 func _get_day_suffix(day: int) -> String:
 	if day >= 11 and day <= 13:
@@ -2125,6 +2131,10 @@ func _on_spell_cast_requested(spell_id: String) -> void:
 			input_handler.ui_blocking_input = true
 			_add_message(input_handler.targeting_system.get_status_text(), Color(0.5, 0.8, 1.0))
 			_add_message(input_handler.targeting_system.get_help_text(), Color(0.7, 0.7, 0.7))
+			# Show visual highlight on the initial target
+			var initial_target = input_handler.targeting_system.get_current_target()
+			if initial_target:
+				update_target_highlight(initial_target)
 		else:
 			_add_message("No valid targets in range.", Color(1.0, 0.8, 0.3))
 	else:

--- a/systems/elemental_system.gd
+++ b/systems/elemental_system.gd
@@ -220,10 +220,10 @@ static func calculate_elemental_damage(base_damage: int, element: String, target
 		result.message = "%s is immune to %s!" % [target.name, element]
 	elif resistance <= -50:
 		result.resisted = true
-		result.message = "%s resists the %s!" % [target.name, element]
+		# Note: resisted message shown by calling system when damage is actually dealt
 	elif resistance >= 50:
 		result.vulnerable = true
-		result.message = "%s is vulnerable to %s!" % [target.name, element]
+		# Note: vulnerable message shown by calling system when damage is actually dealt
 
 	return result
 

--- a/systems/input_handler.gd
+++ b/systems/input_handler.gd
@@ -1610,6 +1610,11 @@ func _update_targeting_display() -> void:
 	elif game and game.has_method("_add_message"):
 		game._add_message(targeting_system.get_status_text(), Color(0.8, 0.9, 1.0))
 
+	# Update visual highlight to show current target
+	var current = targeting_system.get_current_target()
+	if current and game and game.has_method("update_target_highlight"):
+		game.update_target_highlight(current)
+
 
 ## Process the result of a ranged attack
 func _process_ranged_attack_result(result: Dictionary) -> void:
@@ -2304,9 +2309,10 @@ func _exit_look_mode() -> void:
 func _get_entity_description(entity: Entity) -> String:
 	if entity is Enemy:
 		var hp_percent = int((float(entity.current_health) / float(entity.max_health)) * 100)
+		var is_undead = entity.creature_type == "undead"
 		var health_state = "healthy"
 		if hp_percent <= 25:
-			health_state = "near death"
+			health_state = "near destruction" if is_undead else "near death"
 		elif hp_percent <= 50:
 			health_state = "wounded"
 		elif hp_percent <= 75:

--- a/systems/spell_casting_system.gd
+++ b/systems/spell_casting_system.gd
@@ -283,13 +283,12 @@ static func _apply_spell_effects(caster, spell, target, result: Dictionary) -> D
 				result.target_died = true
 
 		# Generate message based on elemental result
-		if elemental_result.get("message", "") != "":
-			result.message = elemental_result.message
-		elif elemental_result.get("immune", false):
+		if elemental_result.get("immune", false):
 			result.message = "%s is immune to %s!" % [target.name if target else "Target", damage_type]
 		elif elemental_result.get("healed", false):
 			result.message = "%s absorbs the %s energy!" % [target.name if target else "Target", damage_type]
 		else:
+			# Always show damage amount in the message
 			result.message = "%s hits %s for %d %s damage!" % [
 				spell.name,
 				target.name if target else "the target",


### PR DESCRIPTION
- Updated ancient_treasure.json to replace generic gems with specific types (garnet, sapphire, emerald, ruby) and adjusted drop chances.
- Modified construct_common.json to introduce amethyst and topaz gems, enhancing loot variety.
- Enhanced CR 11-16 treasure with specific gems (garnet, sapphire, emerald, ruby, diamond) for better scaling.
- Adjusted CR 17+ treasure to include a variety of gems with specific drop chances.
- Updated CR 5-10 treasure to feature amethyst, topaz, garnet, and sapphire gems.
- Revamped demon_common.json to replace generic gems with garnet, ruby, and diamond, improving loot quality.
- Enhanced elemental_common.json to include quartz, amethyst, topaz, and sapphire gems.
- Updated humanoid_common.json to replace generic gems with quartz, amethyst, and topaz.
- Modified humanoid_mage.json to include specific gems (amethyst, sapphire, ruby) instead of generic gems.
- Adjusted monstrosity_common.json to replace generic gems with quartz and garnet.
- Updated ooze_common.json to include quartz and amethyst gems instead of generic gems.
- Enhanced undead_boss.json to replace generic gems with specific types (sapphire, emerald, ruby, diamond).
- Added new gem_type.json to define properties and variants for different gem types.
- Introduced minor_healing.json and sacred_flame.json cantrips to expand spell options.
- Enhanced enemy AI behavior to include fleeing mechanics when under fear effects.
- Improved player item pickup logic to handle gold coins directly.
- Added new features for spell casting and targeting UI to enhance gameplay experience.