### PR TITLE
docs: add v1.7 code refactoring plan documents

### DIFF
--- a/plans/features/v1.7/ideas.md
+++ b/plans/features/v1.7/ideas.md
@@ -1,0 +1,5 @@
+## Version 1.7 Updates 
+---
+
+- [X] Technical Improvements
+

--- a/plans/features/v1.7/refactor-01-json-helper-extend.md
+++ b/plans/features/v1.7/refactor-01-json-helper-extend.md
@@ -1,0 +1,335 @@
+# Refactor 01: Extend JsonHelper
+
+**Risk Level**: Zero
+**Estimated Changes**: 1 file modified, then 10+ files updated
+
+---
+
+## Goal
+
+Extend `autoload/json_helper.gd` to eliminate duplicate code patterns found in 10+ manager files:
+1. Recursive directory scanning for JSON files
+2. Vector2i parsing from various formats
+3. Color parsing from strings
+
+---
+
+## Current State
+
+### JsonHelper (26 lines)
+Currently only has `load_json_file()`:
+```gdscript
+static func load_json_file(path: String) -> Variant:
+    # ... basic JSON loading
+```
+
+### Duplicate Pattern in 10+ Managers
+Each manager duplicates this ~25-line pattern:
+```gdscript
+func _load_*_from_folder(path: String) -> void:
+    var dir = DirAccess.open(path)
+    if not dir:
+        push_warning("...")
+        return
+
+    dir.list_dir_begin()
+    var file_name = dir.get_next()
+
+    while file_name != "":
+        var full_path = path + "/" + file_name
+
+        if dir.current_is_dir():
+            if not file_name.begins_with("."):
+                _load_*_from_folder(full_path)  # Recursive
+        elif file_name.ends_with(".json"):
+            _load_*_from_file(full_path)
+
+        file_name = dir.get_next()
+
+    dir.list_dir_end()
+```
+
+### Duplicate Vector Parsing (3 files)
+```gdscript
+func _parse_vector2i(value) -> Vector2i:
+    if value is Vector2i:
+        return value
+    if value is String:
+        # Parse "(x, y)" format
+    if value is Dictionary:
+        return Vector2i(value.get("x", 0), value.get("y", 0))
+    return Vector2i.ZERO
+```
+
+---
+
+## Implementation
+
+### Step 1: Update autoload/json_helper.gd
+
+Replace the entire file with:
+
+```gdscript
+class_name JsonHelper
+extends Node
+
+## JsonHelper - Utility class for JSON loading and parsing
+##
+## Provides static methods for:
+## - Loading individual JSON files
+## - Recursively loading all JSON files from a directory
+## - Parsing common data types from JSON values
+
+## Load a single JSON file and return its parsed contents
+static func load_json_file(path: String) -> Variant:
+	if not FileAccess.file_exists(path):
+		push_warning("JsonHelper: File not found: %s" % path)
+		return []
+
+	var f = FileAccess.open(path, FileAccess.READ)
+	if not f:
+		push_error("JsonHelper: Could not open file: %s" % path)
+		return []
+
+	var text = f.get_as_text()
+	f.close()
+
+	var j = JSON.new()
+	if j.parse(text) != OK:
+		push_error("JsonHelper: Failed to parse JSON: %s" % path)
+		return []
+
+	return j.data
+
+
+## Recursively load all JSON files from a directory
+## Returns array of dictionaries: [{"path": "...", "data": {...}}, ...]
+static func load_all_from_directory(base_path: String, recursive: bool = true) -> Array[Dictionary]:
+	var results: Array[Dictionary] = []
+	_scan_directory(base_path, recursive, results)
+	return results
+
+
+## Internal recursive directory scanner
+static func _scan_directory(path: String, recursive: bool, results: Array[Dictionary]) -> void:
+	var dir = DirAccess.open(path)
+	if not dir:
+		push_warning("JsonHelper: Could not open directory: %s" % path)
+		return
+
+	dir.list_dir_begin()
+	var file_name = dir.get_next()
+
+	while file_name != "":
+		var full_path = path + "/" + file_name
+
+		if dir.current_is_dir():
+			# Skip hidden folders, recurse into others if enabled
+			if recursive and not file_name.begins_with("."):
+				_scan_directory(full_path, recursive, results)
+		elif file_name.ends_with(".json"):
+			# Load JSON file
+			var data = load_json_file(full_path)
+			if data != null and (data is Dictionary or data is Array):
+				results.append({"path": full_path, "data": data})
+
+		file_name = dir.get_next()
+
+	dir.list_dir_end()
+
+
+## Parse a value into Vector2i from various formats
+## Supports: Vector2i, String "(x, y)", Dictionary {"x": n, "y": n}, Array [x, y]
+static func parse_vector2i(value) -> Vector2i:
+	if value == null:
+		return Vector2i.ZERO
+
+	if value is Vector2i:
+		return value
+
+	if value is Vector2:
+		return Vector2i(int(value.x), int(value.y))
+
+	if value is String:
+		var cleaned = value.strip_edges().replace("(", "").replace(")", "")
+		var parts = cleaned.split(",")
+		if parts.size() != 2:
+			push_warning("JsonHelper: Invalid Vector2i string format: %s" % value)
+			return Vector2i.ZERO
+		return Vector2i(int(parts[0].strip_edges()), int(parts[1].strip_edges()))
+
+	if value is Dictionary:
+		return Vector2i(
+			int(value.get("x", 0)),
+			int(value.get("y", 0))
+		)
+
+	if value is Array and value.size() >= 2:
+		return Vector2i(int(value[0]), int(value[1]))
+
+	push_warning("JsonHelper: Cannot parse Vector2i from type: %s" % typeof(value))
+	return Vector2i.ZERO
+
+
+## Parse a value into Color from various formats
+## Supports: Color, String "#RRGGBB" or "#RRGGBBAA", Dictionary {"r":, "g":, "b":, "a":}
+static func parse_color(value, default: Color = Color.WHITE) -> Color:
+	if value == null:
+		return default
+
+	if value is Color:
+		return value
+
+	if value is String:
+		if value.begins_with("#"):
+			return Color.html(value)
+		# Try named colors
+		var named = Color.from_string(value, default)
+		return named
+
+	if value is Dictionary:
+		return Color(
+			value.get("r", 1.0),
+			value.get("g", 1.0),
+			value.get("b", 1.0),
+			value.get("a", 1.0)
+		)
+
+	if value is Array and value.size() >= 3:
+		return Color(
+			value[0],
+			value[1],
+			value[2],
+			value[3] if value.size() > 3 else 1.0
+		)
+
+	return default
+
+
+## Parse a value into float, with optional default
+static func parse_float(value, default: float = 0.0) -> float:
+	if value == null:
+		return default
+	if value is float or value is int:
+		return float(value)
+	if value is String:
+		if value.is_valid_float():
+			return value.to_float()
+	return default
+
+
+## Parse a value into int, with optional default
+static func parse_int(value, default: int = 0) -> int:
+	if value == null:
+		return default
+	if value is int:
+		return value
+	if value is float:
+		return int(value)
+	if value is String:
+		if value.is_valid_int():
+			return value.to_int()
+	return default
+```
+
+---
+
+### Step 2: Update EntityManager
+
+In `autoload/entity_manager.gd`, replace:
+
+**Remove** the `_load_enemies_from_folder()` method (lines 39-61) and update `_load_enemy_definitions()`:
+
+```gdscript
+## Load all enemy definitions by recursively scanning folders
+func _load_enemy_definitions() -> void:
+	var files = JsonHelper.load_all_from_directory(ENEMY_DATA_BASE_PATH)
+	for file_entry in files:
+		_process_enemy_data(file_entry.path, file_entry.data)
+	#print("EntityManager: Loaded %d enemy definitions" % enemy_definitions.size())
+
+
+## Process loaded enemy data (handles both single and multi-enemy formats)
+func _process_enemy_data(file_path: String, data) -> void:
+	# Handle single enemy file (new format with "id" field)
+	if data is Dictionary and "id" in data:
+		var enemy_id = data.get("id", "")
+		if enemy_id != "":
+			enemy_definitions[enemy_id] = data
+			print("Loaded enemy definition: ", enemy_id)
+		else:
+			push_warning("EntityManager: Enemy without ID in %s" % file_path)
+	# Handle old multi-enemy format for backwards compatibility
+	elif data is Dictionary and "enemies" in data:
+		for enemy_data in data["enemies"]:
+			var enemy_id = enemy_data.get("id", "")
+			if enemy_id != "":
+				enemy_definitions[enemy_id] = enemy_data
+				print("Loaded enemy definition: ", enemy_id)
+			else:
+				push_warning("EntityManager: Enemy without ID in %s" % file_path)
+	else:
+		push_warning("EntityManager: Invalid enemy format in %s" % file_path)
+```
+
+**Remove** `_load_enemy_from_file()` method (lines 64-100+) - functionality absorbed into `_process_enemy_data()`.
+
+**Replace** `_parse_vector2i()` usage with `JsonHelper.parse_vector2i()`.
+
+---
+
+### Step 3: Update Other Managers
+
+Apply similar changes to these files:
+
+| File | Method to Remove | Replacement |
+|------|-----------------|-------------|
+| `feature_manager.gd` | `_load_feature_definitions_recursive()` | Use `JsonHelper.load_all_from_directory()` |
+| `hazard_manager.gd` | `_load_hazard_definitions_recursive()` | Use `JsonHelper.load_all_from_directory()` |
+| `item_manager.gd` | `_load_items_from_folder()` | Use `JsonHelper.load_all_from_directory()` |
+| `recipe_manager.gd` | `_load_recipes_from_folder()` | Use `JsonHelper.load_all_from_directory()` |
+| `spell_manager.gd` | `_load_spells_from_folder()` | Use `JsonHelper.load_all_from_directory()` |
+| `variant_manager.gd` | `_load_templates_from_folder()`, `_load_variants_from_folder()` | Use `JsonHelper.load_all_from_directory()` |
+| `creature_type_manager.gd` | `_load_creature_types_from_folder()` | Use `JsonHelper.load_all_from_directory()` |
+| `tile_type_manager.gd` | `_load_tile_types_from_folder()` | Use `JsonHelper.load_all_from_directory()` |
+| `biome_manager.gd` | `_load_biomes_from_folder()` | Use `JsonHelper.load_all_from_directory()` |
+
+For files using `_parse_vector2i()`:
+| File | Replace With |
+|------|--------------|
+| `entity_manager.gd` | `JsonHelper.parse_vector2i()` |
+| `feature_manager.gd` | `JsonHelper.parse_vector2i()` |
+| `hazard_manager.gd` | `JsonHelper.parse_vector2i()` |
+
+---
+
+## Verification Checklist
+
+After completing all changes:
+
+- [ ] Game launches without errors
+- [ ] Create new world - enemies spawn correctly
+- [ ] Enter dungeon - features appear correctly
+- [ ] Check hazards spawn in appropriate locations
+- [ ] Items can be found/picked up
+- [ ] Spells work correctly
+- [ ] Crafting recipes load and work
+- [ ] Biomes render correctly on overworld
+- [ ] Save game and load - all data preserved
+- [ ] No new console warnings/errors
+
+---
+
+## Rollback
+
+If issues occur:
+```bash
+git checkout HEAD -- autoload/json_helper.gd
+git checkout HEAD -- autoload/entity_manager.gd
+# ... etc for other modified files
+```
+
+Or revert entire commit:
+```bash
+git revert HEAD
+```

--- a/plans/features/v1.7/refactor-02-ui-theme-constants.md
+++ b/plans/features/v1.7/refactor-02-ui-theme-constants.md
@@ -1,0 +1,284 @@
+# Refactor 02: UI Theme Constants
+
+**Risk Level**: Zero
+**Estimated Changes**: 1 new file, 22+ files updated
+
+---
+
+## Goal
+
+Create a centralized `UITheme` autoload containing all shared UI color constants, eliminating duplication across 22+ UI files.
+
+---
+
+## Current State
+
+Multiple UI files define identical or similar color constants:
+
+**inventory_screen.gd (lines 72-78):**
+```gdscript
+const COLOR_SELECTED = Color(0.2, 0.4, 0.3, 1.0)
+const COLOR_NORMAL = Color(0.7, 0.7, 0.7, 1.0)
+const COLOR_EMPTY = Color(0.4, 0.4, 0.4, 1.0)
+const COLOR_EQUIPPED = Color(0.9, 0.85, 0.5, 1.0)
+const COLOR_HIGHLIGHT = Color(1.0, 1.0, 0.6, 1.0)
+const COLOR_PANEL_ACTIVE = Color(0.8, 0.8, 0.5, 1.0)
+const COLOR_PANEL_INACTIVE = Color(0.5, 0.5, 0.4, 1.0)
+```
+
+**shop_screen.gd (lines 59-64):**
+```gdscript
+const COLOR_SELECTED = Color(0.9, 0.85, 0.5, 1.0)
+const COLOR_NORMAL = Color(0.7, 0.7, 0.7, 1.0)
+const COLOR_POSITIVE = Color(0.6, 0.9, 0.6, 1.0)
+const COLOR_NEGATIVE = Color(0.9, 0.5, 0.5, 1.0)
+const COLOR_GOLD = Color(0.9, 0.7, 0.2, 1.0)
+```
+
+Similar patterns found in: container_screen.gd, level_up_screen.gd, crafting_screen.gd, character_sheet.gd, spell_list_screen.gd, and 15+ other UI files.
+
+---
+
+## Implementation
+
+### Step 1: Create autoload/ui_theme.gd
+
+Create new file `autoload/ui_theme.gd`:
+
+```gdscript
+class_name UIThemeConfig
+extends Node
+
+## UITheme - Centralized UI styling constants
+##
+## Use UITheme.COLOR_* throughout UI code for consistent theming.
+## This allows easy theme changes and ensures visual consistency.
+
+# =============================================================================
+# SELECTION & FOCUS COLORS
+# =============================================================================
+
+## Color for currently selected/focused items
+const COLOR_SELECTED = Color(0.2, 0.4, 0.3, 1.0)
+
+## Alternative selection color (for shop, gold-tinted)
+const COLOR_SELECTED_GOLD = Color(0.9, 0.85, 0.5, 1.0)
+
+## Hover/highlight color for emphasized items
+const COLOR_HIGHLIGHT = Color(1.0, 1.0, 0.6, 1.0)
+
+## Normal/unselected item color
+const COLOR_NORMAL = Color(0.7, 0.7, 0.7, 1.0)
+
+## Color for empty slots or placeholders
+const COLOR_EMPTY = Color(0.4, 0.4, 0.4, 1.0)
+
+## Color for disabled/unavailable items
+const COLOR_DISABLED = Color(0.5, 0.5, 0.5, 1.0)
+
+# =============================================================================
+# FEEDBACK COLORS
+# =============================================================================
+
+## Positive feedback (healing, buffs, affordable)
+const COLOR_POSITIVE = Color(0.6, 0.9, 0.6, 1.0)
+
+## Negative feedback (damage, debuffs, expensive)
+const COLOR_NEGATIVE = Color(0.9, 0.5, 0.5, 1.0)
+
+## Warning feedback (low health, encumbered)
+const COLOR_WARNING = Color(0.9, 0.7, 0.2, 1.0)
+
+## Gold/currency color
+const COLOR_GOLD = Color(0.9, 0.7, 0.2, 1.0)
+
+# =============================================================================
+# EQUIPMENT & ITEM COLORS
+# =============================================================================
+
+## Color for equipped items in inventory
+const COLOR_EQUIPPED = Color(0.9, 0.85, 0.5, 1.0)
+
+## Color for magical/enchanted items
+const COLOR_MAGICAL = Color(0.6, 0.7, 1.0, 1.0)
+
+## Color for rare items
+const COLOR_RARE = Color(0.8, 0.6, 1.0, 1.0)
+
+## Color for cursed items
+const COLOR_CURSED = Color(0.8, 0.3, 0.3, 1.0)
+
+# =============================================================================
+# PANEL & SECTION COLORS
+# =============================================================================
+
+## Active panel title/border color
+const COLOR_PANEL_ACTIVE = Color(0.8, 0.8, 0.5, 1.0)
+
+## Inactive panel title/border color
+const COLOR_PANEL_INACTIVE = Color(0.5, 0.5, 0.4, 1.0)
+
+## Section header color
+const COLOR_SECTION_HEADER = Color(0.8, 0.8, 0.5, 1.0)
+
+## Label text color
+const COLOR_LABEL = Color(0.85, 0.85, 0.7, 1.0)
+
+## Value text color
+const COLOR_VALUE = Color(0.7, 0.9, 0.7, 1.0)
+
+# =============================================================================
+# BACKGROUND COLORS
+# =============================================================================
+
+## Standard panel background
+const PANEL_BG_COLOR = Color(0.08, 0.08, 0.12, 0.98)
+
+## Darker panel background for contrast
+const PANEL_BG_DARK = Color(0.05, 0.05, 0.08, 0.98)
+
+## Lighter panel background for emphasis
+const PANEL_BG_LIGHT = Color(0.12, 0.12, 0.16, 0.98)
+
+# =============================================================================
+# STAT CHANGE COLORS
+# =============================================================================
+
+## Stat increase color
+const COLOR_STAT_UP = Color(0.5, 1.0, 0.5, 1.0)
+
+## Stat decrease color
+const COLOR_STAT_DOWN = Color(1.0, 0.5, 0.5, 1.0)
+
+## Stat neutral/unchanged color
+const COLOR_STAT_NEUTRAL = Color(0.8, 0.8, 0.8, 1.0)
+
+# =============================================================================
+# MESSAGE LOG COLORS
+# =============================================================================
+
+## Combat damage message color
+const COLOR_MSG_DAMAGE = Color(1.0, 0.6, 0.6, 1.0)
+
+## Healing message color
+const COLOR_MSG_HEAL = Color(0.6, 1.0, 0.6, 1.0)
+
+## System/info message color
+const COLOR_MSG_INFO = Color(0.7, 0.7, 0.9, 1.0)
+
+## Important/alert message color
+const COLOR_MSG_ALERT = Color(1.0, 0.9, 0.4, 1.0)
+```
+
+---
+
+### Step 2: Register as Autoload
+
+In `project.godot`, add after existing autoloads (around line 52):
+
+```ini
+UITheme="*res://autoload/ui_theme.gd"
+```
+
+---
+
+### Step 3: Update UI Files
+
+For each UI file, replace local color constants with `UITheme.COLOR_*` references.
+
+**Example for inventory_screen.gd:**
+
+Remove lines 72-78:
+```gdscript
+# REMOVE THESE:
+const COLOR_SELECTED = Color(0.2, 0.4, 0.3, 1.0)
+const COLOR_NORMAL = Color(0.7, 0.7, 0.7, 1.0)
+# ... etc
+```
+
+Replace usages throughout the file:
+```gdscript
+# Before:
+label.modulate = COLOR_SELECTED
+# After:
+label.modulate = UITheme.COLOR_SELECTED
+```
+
+---
+
+### Files to Update
+
+| File | Local Constants to Remove |
+|------|--------------------------|
+| `ui/inventory_screen.gd` | COLOR_SELECTED, COLOR_NORMAL, COLOR_EMPTY, COLOR_EQUIPPED, COLOR_HIGHLIGHT, COLOR_PANEL_ACTIVE, COLOR_PANEL_INACTIVE |
+| `ui/shop_screen.gd` | COLOR_SELECTED, COLOR_NORMAL, COLOR_POSITIVE, COLOR_NEGATIVE, COLOR_GOLD |
+| `ui/container_screen.gd` | COLOR_SELECTED, COLOR_NORMAL, COLOR_EMPTY |
+| `ui/level_up_screen.gd` | COLOR_SELECTED, COLOR_NORMAL, COLOR_POSITIVE, COLOR_NEGATIVE |
+| `ui/crafting_screen.gd` | COLOR_SELECTED, COLOR_NORMAL, COLOR_DISABLED |
+| `ui/character_sheet.gd` | COLOR_LABEL, COLOR_VALUE, COLOR_SECTION_HEADER |
+| `ui/spell_list_screen.gd` | COLOR_SELECTED, COLOR_NORMAL, COLOR_DISABLED |
+| `ui/ritual_screen.gd` | COLOR_SELECTED, COLOR_NORMAL, COLOR_DISABLED |
+| `ui/special_actions_screen.gd` | COLOR_SELECTED, COLOR_NORMAL |
+| `ui/world_map_screen.gd` | COLOR_* constants |
+| `ui/help_screen.gd` | COLOR_* constants |
+| `ui/targeting_overlay.gd` | COLOR_* constants |
+| (and remaining UI files) | Check for local color constants |
+
+---
+
+### Step 4: Search and Replace Pattern
+
+For each file, use these replacements (note some files may use different names):
+
+| Old | New |
+|-----|-----|
+| `COLOR_SELECTED` | `UITheme.COLOR_SELECTED` |
+| `COLOR_NORMAL` | `UITheme.COLOR_NORMAL` |
+| `COLOR_EMPTY` | `UITheme.COLOR_EMPTY` |
+| `COLOR_EQUIPPED` | `UITheme.COLOR_EQUIPPED` |
+| `COLOR_HIGHLIGHT` | `UITheme.COLOR_HIGHLIGHT` |
+| `COLOR_POSITIVE` | `UITheme.COLOR_POSITIVE` |
+| `COLOR_NEGATIVE` | `UITheme.COLOR_NEGATIVE` |
+| `COLOR_GOLD` | `UITheme.COLOR_GOLD` |
+| `COLOR_WARNING` | `UITheme.COLOR_WARNING` |
+| `COLOR_DISABLED` | `UITheme.COLOR_DISABLED` |
+| `COLOR_PANEL_ACTIVE` | `UITheme.COLOR_PANEL_ACTIVE` |
+| `COLOR_PANEL_INACTIVE` | `UITheme.COLOR_PANEL_INACTIVE` |
+| `COLOR_SECTION_HEADER` | `UITheme.COLOR_SECTION_HEADER` |
+| `COLOR_LABEL` | `UITheme.COLOR_LABEL` |
+| `COLOR_VALUE` | `UITheme.COLOR_VALUE` |
+
+---
+
+## Verification Checklist
+
+After completing all changes:
+
+- [ ] Game launches without errors
+- [ ] Open Inventory screen (I) - colors correct
+- [ ] Open Shop screen (talk to merchant) - colors correct
+- [ ] Open Character sheet (C) - colors correct
+- [ ] Open Crafting screen (R) - colors correct
+- [ ] Open Spell list (Z) - colors correct
+- [ ] Open Level up screen (gain a level) - colors correct
+- [ ] Open Help screen (?) - colors correct
+- [ ] Open Container (chest) - colors correct
+- [ ] Test selection highlighting in all screens
+- [ ] Test hover states work correctly
+- [ ] No new console warnings/errors
+
+---
+
+## Rollback
+
+If issues occur:
+```bash
+git checkout HEAD -- autoload/ui_theme.gd
+git checkout HEAD -- project.godot
+git checkout HEAD -- ui/
+```
+
+Or revert entire commit:
+```bash
+git revert HEAD
+```

--- a/plans/features/v1.7/refactor-03-inventory-filter-constants.md
+++ b/plans/features/v1.7/refactor-03-inventory-filter-constants.md
@@ -1,0 +1,266 @@
+# Refactor 03: Inventory Filter Constants
+
+**Risk Level**: Zero
+**Estimated Changes**: 3 files modified
+
+---
+
+## Goal
+
+Move duplicated `FILTER_LABELS` and `FILTER_HOTKEYS` constants from `inventory_screen.gd` and `shop_screen.gd` into the `Inventory` class in `inventory_system.gd`.
+
+---
+
+## Current State
+
+### inventory_screen.gd (lines 110-134)
+```gdscript
+const FILTER_LABELS = {
+    Inventory.FilterType.ALL: "All",
+    Inventory.FilterType.WEAPONS: "Weapons",
+    Inventory.FilterType.ARMOR: "Armor",
+    Inventory.FilterType.TOOLS: "Tools",
+    Inventory.FilterType.CONSUMABLES: "Consumables",
+    Inventory.FilterType.MATERIALS: "Materials",
+    Inventory.FilterType.AMMUNITION: "Ammo",
+    Inventory.FilterType.BOOKS: "Books",
+    Inventory.FilterType.SEEDS: "Seeds",
+    Inventory.FilterType.MISC: "Misc"
+}
+
+const FILTER_HOTKEYS = {
+    KEY_1: Inventory.FilterType.ALL,
+    KEY_2: Inventory.FilterType.WEAPONS,
+    KEY_3: Inventory.FilterType.ARMOR,
+    KEY_4: Inventory.FilterType.TOOLS,
+    KEY_5: Inventory.FilterType.CONSUMABLES,
+    KEY_6: Inventory.FilterType.MATERIALS,
+    KEY_7: Inventory.FilterType.AMMUNITION,
+    KEY_8: Inventory.FilterType.BOOKS,
+    KEY_9: Inventory.FilterType.SEEDS,
+    KEY_0: Inventory.FilterType.MISC
+}
+```
+
+### shop_screen.gd (lines 78-103)
+Identical constants (with comment "shared with inventory screen" but actually duplicated):
+```gdscript
+# Filter hotkeys (shared with inventory screen)
+const FILTER_HOTKEYS = { ... }  # IDENTICAL
+const FILTER_LABELS = { ... }   # IDENTICAL
+```
+
+---
+
+## Implementation
+
+### Step 1: Update systems/inventory_system.gd
+
+Add the constants to the `Inventory` class after the `FilterType` enum (around line 580):
+
+```gdscript
+enum FilterType {
+    ALL,           # Show everything (default)
+    WEAPONS,       # Swords, axes, bows, etc.
+    ARMOR,         # All equippable armor pieces
+    TOOLS,         # Knives, hammers, waterskins, etc.
+    CONSUMABLES,   # Food, bandages, potions
+    MATERIALS,     # Crafting materials, ore, leather
+    AMMUNITION,    # Arrows, bolts
+    BOOKS,         # Recipe books
+    SEEDS,         # Farming seeds
+    MISC           # Currency, keys, other items
+}
+
+## Display labels for filter types (used by UI screens)
+const FILTER_LABELS: Dictionary = {
+    FilterType.ALL: "All",
+    FilterType.WEAPONS: "Weapons",
+    FilterType.ARMOR: "Armor",
+    FilterType.TOOLS: "Tools",
+    FilterType.CONSUMABLES: "Consumables",
+    FilterType.MATERIALS: "Materials",
+    FilterType.AMMUNITION: "Ammo",
+    FilterType.BOOKS: "Books",
+    FilterType.SEEDS: "Seeds",
+    FilterType.MISC: "Misc"
+}
+
+## Keyboard shortcuts for filter selection (used by UI screens)
+const FILTER_HOTKEYS: Dictionary = {
+    KEY_1: FilterType.ALL,
+    KEY_2: FilterType.WEAPONS,
+    KEY_3: FilterType.ARMOR,
+    KEY_4: FilterType.TOOLS,
+    KEY_5: FilterType.CONSUMABLES,
+    KEY_6: FilterType.MATERIALS,
+    KEY_7: FilterType.AMMUNITION,
+    KEY_8: FilterType.BOOKS,
+    KEY_9: FilterType.SEEDS,
+    KEY_0: FilterType.MISC
+}
+```
+
+---
+
+### Step 2: Update ui/inventory_screen.gd
+
+**Remove** lines 110-134 (the local FILTER_LABELS and FILTER_HOTKEYS constants).
+
+**Replace** all usages:
+
+| Old | New |
+|-----|-----|
+| `FILTER_LABELS` | `Inventory.FILTER_LABELS` |
+| `FILTER_HOTKEYS` | `Inventory.FILTER_HOTKEYS` |
+
+**Example changes:**
+
+```gdscript
+# Before (around line 148):
+if FILTER_HOTKEYS.has(event.keycode):
+    current_filter = FILTER_HOTKEYS[event.keycode]
+
+# After:
+if Inventory.FILTER_HOTKEYS.has(event.keycode):
+    current_filter = Inventory.FILTER_HOTKEYS[event.keycode]
+```
+
+```gdscript
+# Before (in _update_filter_bar):
+var label_text = "[%d] %s" % [hotkey, FILTER_LABELS[filter_type]]
+
+# After:
+var label_text = "[%d] %s" % [hotkey, Inventory.FILTER_LABELS[filter_type]]
+```
+
+---
+
+### Step 3: Update ui/shop_screen.gd
+
+**Remove** lines 78-103 (the local FILTER_LABELS and FILTER_HOTKEYS constants).
+
+**Replace** all usages:
+
+| Old | New |
+|-----|-----|
+| `FILTER_LABELS` | `Inventory.FILTER_LABELS` |
+| `FILTER_HOTKEYS` | `Inventory.FILTER_HOTKEYS` |
+
+**Example changes:**
+
+```gdscript
+# Before (around line 120):
+if FILTER_HOTKEYS.has(event.keycode):
+    if is_shop_focused:
+        shop_filter = FILTER_HOTKEYS[event.keycode]
+
+# After:
+if Inventory.FILTER_HOTKEYS.has(event.keycode):
+    if is_shop_focused:
+        shop_filter = Inventory.FILTER_HOTKEYS[event.keycode]
+```
+
+---
+
+## Complete Diff Summary
+
+### inventory_system.gd
+```diff
+ enum FilterType {
+     ALL,
+     WEAPONS,
+     ARMOR,
+     TOOLS,
+     CONSUMABLES,
+     MATERIALS,
+     AMMUNITION,
+     BOOKS,
+     SEEDS,
+     MISC
+ }
+
++## Display labels for filter types (used by UI screens)
++const FILTER_LABELS: Dictionary = {
++    FilterType.ALL: "All",
++    FilterType.WEAPONS: "Weapons",
++    FilterType.ARMOR: "Armor",
++    FilterType.TOOLS: "Tools",
++    FilterType.CONSUMABLES: "Consumables",
++    FilterType.MATERIALS: "Materials",
++    FilterType.AMMUNITION: "Ammo",
++    FilterType.BOOKS: "Books",
++    FilterType.SEEDS: "Seeds",
++    FilterType.MISC: "Misc"
++}
++
++## Keyboard shortcuts for filter selection (used by UI screens)
++const FILTER_HOTKEYS: Dictionary = {
++    KEY_1: FilterType.ALL,
++    KEY_2: FilterType.WEAPONS,
++    KEY_3: FilterType.ARMOR,
++    KEY_4: FilterType.TOOLS,
++    KEY_5: FilterType.CONSUMABLES,
++    KEY_6: FilterType.MATERIALS,
++    KEY_7: FilterType.AMMUNITION,
++    KEY_8: FilterType.BOOKS,
++    KEY_9: FilterType.SEEDS,
++    KEY_0: FilterType.MISC
++}
++
+ ## Get all items as array (for UI display)
+ func get_all_items() -> Array[Item]:
+```
+
+### inventory_screen.gd
+```diff
+-# Filter configuration
+-const FILTER_LABELS = {
+-    Inventory.FilterType.ALL: "All",
+-    ... (24 lines removed)
+-}
+-
+-const FILTER_HOTKEYS = {
+-    KEY_1: Inventory.FilterType.ALL,
+-    ... (24 lines removed)
+-}
+```
+
+Then replace all occurrences of `FILTER_LABELS` with `Inventory.FILTER_LABELS` and `FILTER_HOTKEYS` with `Inventory.FILTER_HOTKEYS`.
+
+### shop_screen.gd
+Same changes as inventory_screen.gd - remove local constants and update references.
+
+---
+
+## Verification Checklist
+
+After completing all changes:
+
+- [ ] Game launches without errors
+- [ ] Open Inventory (I key)
+  - [ ] Press 1-0 keys to filter items
+  - [ ] Filter labels display correctly in filter bar
+  - [ ] Correct items shown for each filter
+- [ ] Open Shop (talk to merchant)
+  - [ ] Press 1-0 keys to filter shop/player items
+  - [ ] Filter labels display correctly
+  - [ ] Correct items shown for each filter
+- [ ] Filters work identically to before
+- [ ] No new console warnings/errors
+
+---
+
+## Rollback
+
+If issues occur:
+```bash
+git checkout HEAD -- systems/inventory_system.gd
+git checkout HEAD -- ui/inventory_screen.gd
+git checkout HEAD -- ui/shop_screen.gd
+```
+
+Or revert entire commit:
+```bash
+git revert HEAD
+```

--- a/plans/features/v1.7/refactor-04-chunk-cleanup-mixin.md
+++ b/plans/features/v1.7/refactor-04-chunk-cleanup-mixin.md
@@ -1,0 +1,248 @@
+# Refactor 04: Chunk Cleanup Mixin
+
+**Risk Level**: Low
+**Estimated Changes**: 1 new file, 4 files updated
+
+---
+
+## Goal
+
+Create a shared utility for chunk cleanup logic that is duplicated across 4 managers:
+- EntityManager
+- FeatureManager
+- HazardManager
+- StructureManager
+
+---
+
+## Current State
+
+Each manager implements similar `_on_chunk_unloaded()` handlers:
+
+**entity_manager.gd:**
+```gdscript
+func _on_chunk_unloaded(chunk_coords: Vector2i) -> void:
+    var removed_count = 0
+    for i in range(entities.size() - 1, -1, -1):
+        var entity = entities[i]
+        if entity.source_chunk == chunk_coords:
+            entities.remove_at(i)
+            removed_count += 1
+
+    if removed_count > 0:
+        print("[EntityManager] Cleaned up %d entities from chunk %s" % [removed_count, chunk_coords])
+```
+
+Similar patterns in feature_manager.gd, hazard_manager.gd, and structure_manager.gd.
+
+---
+
+## Implementation
+
+### Step 1: Create autoload/chunk_cleanup_helper.gd
+
+```gdscript
+class_name ChunkCleanupHelper
+extends RefCounted
+
+## ChunkCleanupHelper - Utility for cleaning up entities when chunks unload
+##
+## Provides static methods for removing items from collections based on chunk coordinates.
+## Used by EntityManager, FeatureManager, HazardManager, and StructureManager.
+
+const ChunkManagerClass = preload("res://autoload/chunk_manager.gd")
+
+
+## Remove items from an array where item.source_chunk matches the given chunk
+## Returns the number of items removed
+## Items must have a 'source_chunk' property of type Vector2i
+static func cleanup_array_by_chunk(arr: Array, chunk_coords: Vector2i, manager_name: String = "") -> int:
+	var removed_count = 0
+
+	# Iterate backwards to safely remove items
+	for i in range(arr.size() - 1, -1, -1):
+		var item = arr[i]
+		if item.has_method("get") or "source_chunk" in item:
+			var item_chunk = item.source_chunk if "source_chunk" in item else null
+			if item_chunk == chunk_coords:
+				arr.remove_at(i)
+				removed_count += 1
+
+	if removed_count > 0 and manager_name != "":
+		print("[%s] Cleaned up %d items from chunk %s" % [manager_name, removed_count, chunk_coords])
+
+	return removed_count
+
+
+## Remove items from a dictionary where value.source_chunk matches the given chunk
+## Returns the number of items removed
+static func cleanup_dict_by_chunk(dict: Dictionary, chunk_coords: Vector2i, manager_name: String = "") -> int:
+	var removed_count = 0
+	var keys_to_remove: Array = []
+
+	for key in dict:
+		var item = dict[key]
+		if item != null and "source_chunk" in item:
+			if item.source_chunk == chunk_coords:
+				keys_to_remove.append(key)
+
+	for key in keys_to_remove:
+		dict.erase(key)
+		removed_count += 1
+
+	if removed_count > 0 and manager_name != "":
+		print("[%s] Cleaned up %d items from chunk %s" % [manager_name, removed_count, chunk_coords])
+
+	return removed_count
+
+
+## Remove positions from a dictionary where the position falls within the given chunk
+## Useful for position-keyed dictionaries like ground_items or placed_features
+static func cleanup_positions_in_chunk(dict: Dictionary, chunk_coords: Vector2i, manager_name: String = "") -> int:
+	var removed_count = 0
+	var keys_to_remove: Array = []
+
+	for pos in dict:
+		if pos is Vector2i:
+			var pos_chunk = ChunkManagerClass.world_to_chunk(pos)
+			if pos_chunk == chunk_coords:
+				keys_to_remove.append(pos)
+
+	for key in keys_to_remove:
+		dict.erase(key)
+		removed_count += 1
+
+	if removed_count > 0 and manager_name != "":
+		print("[%s] Cleaned up %d positions from chunk %s" % [manager_name, removed_count, chunk_coords])
+
+	return removed_count
+
+
+## Check if a position is within a given chunk
+static func is_position_in_chunk(position: Vector2i, chunk_coords: Vector2i) -> bool:
+	var pos_chunk = ChunkManagerClass.world_to_chunk(position)
+	return pos_chunk == chunk_coords
+```
+
+---
+
+### Step 2: Update autoload/entity_manager.gd
+
+**Replace** the `_on_chunk_unloaded` method:
+
+```gdscript
+# Before:
+func _on_chunk_unloaded(chunk_coords: Vector2i) -> void:
+    var removed_count = 0
+    for i in range(entities.size() - 1, -1, -1):
+        var entity = entities[i]
+        if entity.source_chunk == chunk_coords:
+            entities.remove_at(i)
+            removed_count += 1
+
+    if removed_count > 0:
+        print("[EntityManager] Cleaned up %d entities from chunk %s" % [removed_count, chunk_coords])
+
+# After:
+func _on_chunk_unloaded(chunk_coords: Vector2i) -> void:
+    ChunkCleanupHelper.cleanup_array_by_chunk(entities, chunk_coords, "EntityManager")
+```
+
+---
+
+### Step 3: Update autoload/feature_manager.gd
+
+**Replace** the `_on_chunk_unloaded` method:
+
+```gdscript
+# Before:
+func _on_chunk_unloaded(chunk_coords: Vector2i) -> void:
+    var removed_count = 0
+    # ... similar cleanup logic for placed_features dictionary
+
+# After:
+func _on_chunk_unloaded(chunk_coords: Vector2i) -> void:
+    ChunkCleanupHelper.cleanup_positions_in_chunk(placed_features, chunk_coords, "FeatureManager")
+```
+
+---
+
+### Step 4: Update autoload/hazard_manager.gd
+
+**Replace** the `_on_chunk_unloaded` method:
+
+```gdscript
+# Before:
+func _on_chunk_unloaded(chunk_coords: Vector2i) -> void:
+    var removed_count = 0
+    # ... similar cleanup logic
+
+# After:
+func _on_chunk_unloaded(chunk_coords: Vector2i) -> void:
+    ChunkCleanupHelper.cleanup_positions_in_chunk(active_hazards, chunk_coords, "HazardManager")
+```
+
+---
+
+### Step 5: Update autoload/structure_manager.gd
+
+**Replace** the `_on_chunk_unloaded` method:
+
+```gdscript
+# Before:
+func _on_chunk_unloaded(chunk_coords: Vector2i) -> void:
+    # ... similar cleanup logic
+
+# After:
+func _on_chunk_unloaded(chunk_coords: Vector2i) -> void:
+    ChunkCleanupHelper.cleanup_positions_in_chunk(placed_structures, chunk_coords, "StructureManager")
+```
+
+---
+
+## Note on Implementation
+
+This is **not** registered as an autoload since it only contains static methods. The class is used via `ChunkCleanupHelper.method_name()` syntax.
+
+If any manager needs instance-specific cleanup logic beyond the standard patterns, they can still implement custom code alongside the helper calls.
+
+---
+
+## Verification Checklist
+
+After completing all changes:
+
+- [ ] Game launches without errors
+- [ ] Start new game in overworld
+- [ ] Walk around to load/unload chunks
+  - [ ] Check console for cleanup messages
+  - [ ] Verify entities disappear when chunks unload
+  - [ ] Verify they reappear when chunks reload
+- [ ] Enter and exit dungeon
+  - [ ] Features clean up properly
+  - [ ] Hazards clean up properly
+- [ ] Place structures (campfire, etc.)
+  - [ ] Walk away until chunk unloads
+  - [ ] Return - structure should be saved/restored
+- [ ] Save and load game
+  - [ ] All positions preserved correctly
+- [ ] No memory leaks (entity count stable over time)
+- [ ] No new console warnings/errors
+
+---
+
+## Rollback
+
+If issues occur:
+```bash
+git checkout HEAD -- autoload/chunk_cleanup_helper.gd
+git checkout HEAD -- autoload/entity_manager.gd
+git checkout HEAD -- autoload/feature_manager.gd
+git checkout HEAD -- autoload/hazard_manager.gd
+git checkout HEAD -- autoload/structure_manager.gd
+```
+
+Or revert entire commit:
+```bash
+git revert HEAD
+```

--- a/plans/features/v1.7/refactor-05-input-mode-handlers.md
+++ b/plans/features/v1.7/refactor-05-input-mode-handlers.md
@@ -1,0 +1,966 @@
+# Refactor 05: Input Mode Handlers
+
+**Risk Level**: Low
+**Estimated Changes**: 4 new files, 1 file significantly reduced
+
+---
+
+## Goal
+
+Extract 7 input mode handlers from `input_handler.gd` (2,569 lines) into separate classes:
+- HarvestModeHandler
+- FishingModeHandler
+- FarmingModeHandler (tilling + planting)
+- LookModeHandler
+
+The existing `TargetingSystem` already follows this pattern and remains unchanged.
+
+---
+
+## Current State
+
+### input_handler.gd Mode State Variables (lines 35-77)
+```gdscript
+# Harvest mode
+var _awaiting_harvest_direction: bool = false
+var _harvesting_active: bool = false
+var _harvest_direction: Vector2i = Vector2i.ZERO
+var _harvest_timer: float = 0.0
+
+# Fishing mode
+var _awaiting_fishing_direction: bool = false
+var _fishing_active: bool = false
+var _fishing_direction: Vector2i = Vector2i.ZERO
+var _fishing_timer: float = 0.0
+
+# Farming modes
+var _awaiting_till_direction: bool = false
+var _awaiting_plant_direction: bool = false
+var _selected_seed_for_planting: Item = null
+var _available_seeds: Array = []
+var _current_seed_index: int = 0
+
+# Trap disarm mode
+var _awaiting_disarm_trap_direction: bool = false
+
+# Look mode
+var look_mode_active: bool = false
+var look_objects: Array = []
+var look_index: int = 0
+var current_look_object = null
+```
+
+Each mode has:
+- State variables
+- Direction key handling
+- Cancel (Escape) handling
+- Continuous action processing (some modes)
+- Start/stop functions
+
+---
+
+## Implementation
+
+### Step 1: Create systems/input_modes/ Directory
+
+```bash
+mkdir -p systems/input_modes
+```
+
+---
+
+### Step 2: Create systems/input_modes/harvest_mode_handler.gd
+
+```gdscript
+class_name HarvestModeHandler
+extends RefCounted
+
+## HarvestModeHandler - Handles harvest direction selection and continuous harvesting
+##
+## Extracted from InputHandler to reduce file size and improve maintainability.
+
+const HarvestSystemClass = preload("res://systems/harvest_system.gd")
+
+signal harvest_completed()
+signal harvest_cancelled()
+
+# State
+var awaiting_direction: bool = false
+var active: bool = false
+var direction: Vector2i = Vector2i.ZERO
+var timer: float = 0.0
+
+# References
+var player: Player = null
+
+# Constants
+const HARVEST_DELAY: float = 0.3
+
+
+func _init(p: Player = null) -> void:
+	player = p
+
+
+func set_player(p: Player) -> void:
+	player = p
+
+
+## Start harvest mode - waits for direction input
+func start() -> void:
+	if awaiting_direction or active:
+		# Already in harvest mode - cancel it
+		cancel()
+		return
+
+	awaiting_direction = true
+	EventBus.message_logged.emit("Harvest in which direction? (WASD/Arrows, Escape to cancel)")
+
+
+## Cancel harvest mode
+func cancel() -> void:
+	if active:
+		active = false
+		direction = Vector2i.ZERO
+		timer = 0.0
+		EventBus.message_logged.emit("Stopped harvesting.")
+
+	if awaiting_direction:
+		awaiting_direction = false
+		EventBus.message_logged.emit("Harvest cancelled.")
+
+	harvest_cancelled.emit()
+
+
+## Check if this handler should process the input
+func wants_input() -> bool:
+	return awaiting_direction or active
+
+
+## Handle input event, returns true if consumed
+func handle_input(event: InputEvent) -> bool:
+	if not event is InputEventKey or not event.pressed or event.echo:
+		return false
+
+	# Handle direction selection
+	if awaiting_direction:
+		var dir = _get_direction_from_key(event.keycode)
+		if dir != Vector2i.ZERO:
+			return _try_start_harvest(dir)
+		elif event.keycode == KEY_ESCAPE:
+			cancel()
+			return true
+
+	# Handle active harvesting cancellation
+	if active:
+		if event.keycode == KEY_ESCAPE or event.keycode == KEY_H:
+			cancel()
+			return true
+
+	return false
+
+
+## Process continuous harvesting (called from _process)
+func process(delta: float) -> bool:
+	if not active or direction == Vector2i.ZERO:
+		return false
+
+	timer -= delta
+	if timer <= 0:
+		timer = HARVEST_DELAY
+		return _perform_harvest_action()
+
+	return false
+
+
+## Check if actively harvesting
+func is_active() -> bool:
+	return active
+
+
+## Get direction from keycode
+func _get_direction_from_key(keycode: int) -> Vector2i:
+	match keycode:
+		KEY_W, KEY_UP, KEY_KP_8:
+			return Vector2i(0, -1)
+		KEY_S, KEY_DOWN, KEY_KP_2:
+			return Vector2i(0, 1)
+		KEY_A, KEY_LEFT, KEY_KP_4:
+			return Vector2i(-1, 0)
+		KEY_D, KEY_RIGHT, KEY_KP_6:
+			return Vector2i(1, 0)
+		KEY_KP_7:
+			return Vector2i(-1, -1)
+		KEY_KP_9:
+			return Vector2i(1, -1)
+		KEY_KP_1:
+			return Vector2i(-1, 1)
+		KEY_KP_3:
+			return Vector2i(1, 1)
+	return Vector2i.ZERO
+
+
+## Try to start harvesting in the given direction
+func _try_start_harvest(dir: Vector2i) -> bool:
+	if player == null:
+		return false
+
+	var target_pos = player.position + dir
+	var resource = HarvestSystemClass.get_resource_at(target_pos)
+
+	if resource == null:
+		EventBus.message_logged.emit("Nothing to harvest there.")
+		awaiting_direction = false
+		return true
+
+	# Start harvesting
+	awaiting_direction = false
+	direction = dir
+	active = true
+	timer = 0.0  # Immediate first harvest
+
+	EventBus.message_logged.emit("Harvesting %s... (Escape or H to stop)" % resource.name)
+	return true
+
+
+## Perform one harvest action
+func _perform_harvest_action() -> bool:
+	if player == null:
+		cancel()
+		return false
+
+	var target_pos = player.position + direction
+	var result = HarvestSystemClass.try_harvest(player, target_pos)
+
+	if not result.success:
+		# Resource depleted or removed
+		cancel()
+		harvest_completed.emit()
+		return false
+
+	# Advance turn for harvest action
+	TurnManager.advance_turn()
+	return true
+```
+
+---
+
+### Step 3: Create systems/input_modes/fishing_mode_handler.gd
+
+```gdscript
+class_name FishingModeHandler
+extends RefCounted
+
+## FishingModeHandler - Handles fishing direction selection and continuous fishing
+##
+## Extracted from InputHandler to reduce file size and improve maintainability.
+
+const FishingSystemClass = preload("res://systems/fishing_system.gd")
+
+signal fishing_completed()
+signal fishing_cancelled()
+
+# State
+var awaiting_direction: bool = false
+var active: bool = false
+var direction: Vector2i = Vector2i.ZERO
+var timer: float = 0.0
+
+# References
+var player: Player = null
+
+# Constants
+const FISHING_DELAY: float = 0.5
+
+
+func _init(p: Player = null) -> void:
+	player = p
+
+
+func set_player(p: Player) -> void:
+	player = p
+
+
+## Start fishing mode - waits for direction input
+func start() -> void:
+	if awaiting_direction or active:
+		cancel()
+		return
+
+	awaiting_direction = true
+	EventBus.message_logged.emit("Fish in which direction? (WASD/Arrows, Escape to cancel)")
+
+
+## Cancel fishing mode
+func cancel() -> void:
+	if active:
+		active = false
+		direction = Vector2i.ZERO
+		timer = 0.0
+		EventBus.message_logged.emit("Stopped fishing.")
+
+	if awaiting_direction:
+		awaiting_direction = false
+		EventBus.message_logged.emit("Fishing cancelled.")
+
+	fishing_cancelled.emit()
+
+
+## Check if this handler should process the input
+func wants_input() -> bool:
+	return awaiting_direction or active
+
+
+## Handle input event, returns true if consumed
+func handle_input(event: InputEvent) -> bool:
+	if not event is InputEventKey or not event.pressed or event.echo:
+		return false
+
+	if awaiting_direction:
+		var dir = _get_direction_from_key(event.keycode)
+		if dir != Vector2i.ZERO:
+			return _try_start_fishing(dir)
+		elif event.keycode == KEY_ESCAPE:
+			cancel()
+			return true
+
+	if active:
+		if event.keycode == KEY_ESCAPE or event.keycode == KEY_F:
+			cancel()
+			return true
+
+	return false
+
+
+## Process continuous fishing (called from _process)
+func process(delta: float) -> bool:
+	if not active or direction == Vector2i.ZERO:
+		return false
+
+	timer -= delta
+	if timer <= 0:
+		timer = FISHING_DELAY
+		return _perform_fishing_action()
+
+	return false
+
+
+## Check if actively fishing
+func is_active() -> bool:
+	return active
+
+
+func _get_direction_from_key(keycode: int) -> Vector2i:
+	match keycode:
+		KEY_W, KEY_UP, KEY_KP_8:
+			return Vector2i(0, -1)
+		KEY_S, KEY_DOWN, KEY_KP_2:
+			return Vector2i(0, 1)
+		KEY_A, KEY_LEFT, KEY_KP_4:
+			return Vector2i(-1, 0)
+		KEY_D, KEY_RIGHT, KEY_KP_6:
+			return Vector2i(1, 0)
+	return Vector2i.ZERO
+
+
+func _try_start_fishing(dir: Vector2i) -> bool:
+	if player == null:
+		return false
+
+	var target_pos = player.position + dir
+
+	# Check for water tile
+	if not FishingSystemClass.can_fish_at(player, target_pos):
+		EventBus.message_logged.emit("Can't fish there.")
+		awaiting_direction = false
+		return true
+
+	awaiting_direction = false
+	direction = dir
+	active = true
+	timer = 0.0
+
+	EventBus.message_logged.emit("Fishing... (Escape or F to stop)")
+	return true
+
+
+func _perform_fishing_action() -> bool:
+	if player == null:
+		cancel()
+		return false
+
+	var target_pos = player.position + direction
+	var result = FishingSystemClass.try_fish(player, target_pos)
+
+	# Fishing always advances turn
+	TurnManager.advance_turn()
+
+	# Continue fishing unless explicitly cancelled
+	return true
+```
+
+---
+
+### Step 4: Create systems/input_modes/farming_mode_handler.gd
+
+```gdscript
+class_name FarmingModeHandler
+extends RefCounted
+
+## FarmingModeHandler - Handles tilling and planting actions
+##
+## Extracted from InputHandler to reduce file size and improve maintainability.
+
+const FarmingSystemClass = preload("res://systems/farming_system.gd")
+
+signal action_completed()
+signal action_cancelled()
+
+enum Mode { NONE, TILL, PLANT }
+
+# State
+var current_mode: Mode = Mode.NONE
+var awaiting_direction: bool = false
+var selected_seed: Item = null
+var available_seeds: Array = []
+var current_seed_index: int = 0
+
+# References
+var player: Player = null
+
+
+func _init(p: Player = null) -> void:
+	player = p
+
+
+func set_player(p: Player) -> void:
+	player = p
+
+
+## Start tilling mode
+func start_till() -> void:
+	if awaiting_direction:
+		cancel()
+		return
+
+	current_mode = Mode.TILL
+	awaiting_direction = true
+	EventBus.message_logged.emit("Till in which direction? (WASD/Arrows, Escape to cancel)")
+
+
+## Start planting mode
+func start_plant() -> void:
+	if player == null:
+		return
+
+	if awaiting_direction:
+		cancel()
+		return
+
+	# Find available seeds
+	available_seeds = _get_plantable_seeds()
+	if available_seeds.is_empty():
+		EventBus.message_logged.emit("You have no seeds to plant.")
+		return
+
+	current_mode = Mode.PLANT
+	awaiting_direction = true
+	current_seed_index = 0
+	selected_seed = available_seeds[0]
+
+	EventBus.message_logged.emit("Plant %s in which direction? (WASD/Arrows, Tab to cycle seeds, Escape to cancel)" % selected_seed.display_name)
+
+
+## Cycle to next available seed (Tab key)
+func cycle_seed() -> void:
+	if current_mode != Mode.PLANT or available_seeds.size() <= 1:
+		return
+
+	current_seed_index = (current_seed_index + 1) % available_seeds.size()
+	selected_seed = available_seeds[current_seed_index]
+	EventBus.message_logged.emit("Selected: %s" % selected_seed.display_name)
+
+
+## Cancel current farming mode
+func cancel() -> void:
+	if awaiting_direction:
+		match current_mode:
+			Mode.TILL:
+				EventBus.message_logged.emit("Tilling cancelled.")
+			Mode.PLANT:
+				EventBus.message_logged.emit("Planting cancelled.")
+
+	current_mode = Mode.NONE
+	awaiting_direction = false
+	selected_seed = null
+	available_seeds.clear()
+	current_seed_index = 0
+	action_cancelled.emit()
+
+
+## Check if this handler should process the input
+func wants_input() -> bool:
+	return awaiting_direction
+
+
+## Handle input event, returns true if consumed
+func handle_input(event: InputEvent) -> bool:
+	if not awaiting_direction:
+		return false
+
+	if not event is InputEventKey or not event.pressed or event.echo:
+		return false
+
+	# Cycle seeds with Tab in plant mode
+	if current_mode == Mode.PLANT and event.keycode == KEY_TAB:
+		cycle_seed()
+		return true
+
+	# Direction input
+	var dir = _get_direction_from_key(event.keycode)
+	if dir != Vector2i.ZERO:
+		match current_mode:
+			Mode.TILL:
+				return _try_till(dir)
+			Mode.PLANT:
+				return _try_plant(dir)
+
+	# Cancel
+	if event.keycode == KEY_ESCAPE:
+		cancel()
+		return true
+
+	return false
+
+
+func _get_direction_from_key(keycode: int) -> Vector2i:
+	match keycode:
+		KEY_W, KEY_UP, KEY_KP_8:
+			return Vector2i(0, -1)
+		KEY_S, KEY_DOWN, KEY_KP_2:
+			return Vector2i(0, 1)
+		KEY_A, KEY_LEFT, KEY_KP_4:
+			return Vector2i(-1, 0)
+		KEY_D, KEY_RIGHT, KEY_KP_6:
+			return Vector2i(1, 0)
+	return Vector2i.ZERO
+
+
+func _try_till(dir: Vector2i) -> bool:
+	if player == null:
+		return false
+
+	var target_pos = player.position + dir
+	var result = FarmingSystemClass.try_till(player, target_pos)
+
+	awaiting_direction = false
+	current_mode = Mode.NONE
+
+	if result.success:
+		TurnManager.advance_turn()
+
+	action_completed.emit()
+	return true
+
+
+func _try_plant(dir: Vector2i) -> bool:
+	if player == null or selected_seed == null:
+		return false
+
+	var target_pos = player.position + dir
+	var result = FarmingSystemClass.try_plant(player, target_pos, selected_seed)
+
+	awaiting_direction = false
+	current_mode = Mode.NONE
+	selected_seed = null
+	available_seeds.clear()
+
+	if result.success:
+		TurnManager.advance_turn()
+
+	action_completed.emit()
+	return true
+
+
+func _get_plantable_seeds() -> Array:
+	if player == null or player.inventory == null:
+		return []
+
+	var seeds: Array = []
+	for item in player.inventory.items:
+		if item.item_type == "seed":
+			seeds.append(item)
+	return seeds
+```
+
+---
+
+### Step 5: Create systems/input_modes/look_mode_handler.gd
+
+```gdscript
+class_name LookModeHandler
+extends RefCounted
+
+## LookModeHandler - Handles look/examine mode for inspecting visible objects
+##
+## Extracted from InputHandler to reduce file size and improve maintainability.
+
+const FOVSystemClass = preload("res://systems/fov_system.gd")
+
+signal object_changed(obj)
+signal mode_exited()
+
+# State
+var active: bool = false
+var objects: Array = []
+var current_index: int = 0
+var current_object = null
+
+# References
+var player: Player = null
+
+
+func _init(p: Player = null) -> void:
+	player = p
+
+
+func set_player(p: Player) -> void:
+	player = p
+
+
+## Start look mode - gather all visible objects
+func start() -> void:
+	if player == null:
+		return
+
+	if active:
+		stop()
+		return
+
+	# Gather visible objects
+	objects = _gather_visible_objects()
+
+	if objects.is_empty():
+		EventBus.message_logged.emit("Nothing visible to examine.")
+		return
+
+	active = true
+	current_index = 0
+	_select_object(0)
+
+	EventBus.message_logged.emit("Look mode: Tab/Shift+Tab to cycle, Escape to exit")
+
+
+## Stop look mode
+func stop() -> void:
+	active = false
+	objects.clear()
+	current_index = 0
+	current_object = null
+	mode_exited.emit()
+
+
+## Check if look mode is active
+func is_active() -> bool:
+	return active
+
+
+## Check if this handler should process the input
+func wants_input() -> bool:
+	return active
+
+
+## Handle input event, returns true if consumed
+func handle_input(event: InputEvent) -> bool:
+	if not active:
+		return false
+
+	if not event is InputEventKey or not event.pressed or event.echo:
+		return false
+
+	match event.keycode:
+		KEY_TAB:
+			if event.shift_pressed:
+				_cycle_previous()
+			else:
+				_cycle_next()
+			return true
+		KEY_ESCAPE, KEY_L:
+			stop()
+			return true
+
+	return false
+
+
+## Get the currently looked-at object
+func get_current_object():
+	return current_object
+
+
+## Cycle to next object
+func _cycle_next() -> void:
+	if objects.is_empty():
+		return
+	current_index = (current_index + 1) % objects.size()
+	_select_object(current_index)
+
+
+## Cycle to previous object
+func _cycle_previous() -> void:
+	if objects.is_empty():
+		return
+	current_index = (current_index - 1 + objects.size()) % objects.size()
+	_select_object(current_index)
+
+
+## Select object at index and emit signal
+func _select_object(index: int) -> void:
+	if index < 0 or index >= objects.size():
+		return
+
+	current_object = objects[index]
+	object_changed.emit(current_object)
+
+	# Display description
+	var desc = _get_object_description(current_object)
+	EventBus.message_logged.emit("[%d/%d] %s" % [index + 1, objects.size(), desc])
+
+
+## Get description for an object
+func _get_object_description(obj) -> String:
+	if obj == null:
+		return "Nothing"
+
+	# Entity (enemy, NPC)
+	if obj is Entity:
+		if obj.has_method("get_display_name"):
+			return obj.get_display_name()
+		return obj.display_name if "display_name" in obj else "Entity"
+
+	# Item (ground item)
+	if obj is Item:
+		return obj.display_name if obj.display_name else "Item"
+
+	# Feature
+	if obj is Dictionary and "feature_id" in obj:
+		return obj.get("name", "Feature")
+
+	# Ground item wrapper
+	if "item" in obj:
+		return obj.item.display_name if obj.item else "Item"
+
+	return str(obj)
+
+
+## Gather all visible objects in FOV
+func _gather_visible_objects() -> Array:
+	var result: Array = []
+
+	if player == null:
+		return result
+
+	var current_map = MapManager.current_map
+	if current_map == null:
+		return result
+
+	# Get visible tiles from FOV
+	var visible_positions = FOVSystemClass.get_visible_positions()
+
+	# Add entities
+	for entity in EntityManager.entities:
+		if entity != player and entity.position in visible_positions:
+			result.append(entity)
+
+	# Add ground items
+	for pos in visible_positions:
+		var items_at_pos = current_map.get_items_at(pos)
+		for item in items_at_pos:
+			result.append({"position": pos, "item": item})
+
+	# Add features
+	for pos in visible_positions:
+		var feature = FeatureManager.get_feature_at(pos)
+		if feature:
+			result.append(feature)
+
+	# Sort by distance to player
+	result.sort_custom(func(a, b):
+		var pos_a = _get_object_position(a)
+		var pos_b = _get_object_position(b)
+		var dist_a = player.position.distance_squared_to(pos_a)
+		var dist_b = player.position.distance_squared_to(pos_b)
+		return dist_a < dist_b
+	)
+
+	return result
+
+
+## Get position of an object
+func _get_object_position(obj) -> Vector2i:
+	if obj is Entity:
+		return obj.position
+	if obj is Dictionary:
+		if "position" in obj:
+			return obj.position
+	return Vector2i.ZERO
+```
+
+---
+
+### Step 6: Update systems/input_handler.gd
+
+1. **Add preloads** at top of file:
+```gdscript
+const HarvestModeHandlerClass = preload("res://systems/input_modes/harvest_mode_handler.gd")
+const FishingModeHandlerClass = preload("res://systems/input_modes/fishing_mode_handler.gd")
+const FarmingModeHandlerClass = preload("res://systems/input_modes/farming_mode_handler.gd")
+const LookModeHandlerClass = preload("res://systems/input_modes/look_mode_handler.gd")
+```
+
+2. **Replace state variables** (lines 35-77) with handler instances:
+```gdscript
+# Mode handlers
+var harvest_handler: HarvestModeHandler = null
+var fishing_handler: FishingModeHandler = null
+var farming_handler: FarmingModeHandler = null
+var look_handler: LookModeHandler = null
+```
+
+3. **Initialize handlers** in `_ready()`:
+```gdscript
+func _ready() -> void:
+	# ... existing code ...
+	harvest_handler = HarvestModeHandlerClass.new()
+	fishing_handler = FishingModeHandlerClass.new()
+	farming_handler = FarmingModeHandlerClass.new()
+	look_handler = LookModeHandlerClass.new()
+
+	# Connect handler signals
+	look_handler.object_changed.connect(_on_look_object_changed)
+```
+
+4. **Update `set_player()`**:
+```gdscript
+func set_player(p: Player) -> void:
+	player = p
+	harvest_handler.set_player(p)
+	fishing_handler.set_player(p)
+	farming_handler.set_player(p)
+	look_handler.set_player(p)
+```
+
+5. **Simplify `_unhandled_input()`** - delegate to handlers:
+```gdscript
+func _unhandled_input(event: InputEvent) -> void:
+	# ... existing checks ...
+
+	# Check mode handlers first
+	if look_handler.wants_input():
+		if look_handler.handle_input(event):
+			get_viewport().set_input_as_handled()
+			return
+
+	if harvest_handler.wants_input():
+		if harvest_handler.handle_input(event):
+			get_viewport().set_input_as_handled()
+			return
+
+	if fishing_handler.wants_input():
+		if fishing_handler.handle_input(event):
+			get_viewport().set_input_as_handled()
+			return
+
+	if farming_handler.wants_input():
+		if farming_handler.handle_input(event):
+			get_viewport().set_input_as_handled()
+			return
+
+	# ... rest of existing input handling ...
+```
+
+6. **Simplify `_process()`** - delegate continuous processing:
+```gdscript
+func _process(delta: float) -> void:
+	# ... existing checks ...
+
+	# Process continuous modes
+	if harvest_handler.is_active():
+		if harvest_handler.process(delta):
+			return
+
+	if fishing_handler.is_active():
+		if fishing_handler.process(delta):
+			return
+
+	# ... rest of existing processing ...
+```
+
+7. **Remove old mode-specific methods** and replace with handler calls:
+```gdscript
+# Before:
+func start_harvest_mode() -> void:
+	# ... 20+ lines of code ...
+
+# After:
+func start_harvest_mode() -> void:
+	harvest_handler.start()
+```
+
+---
+
+## Files Summary
+
+### New Files
+- `systems/input_modes/harvest_mode_handler.gd` (~150 lines)
+- `systems/input_modes/fishing_mode_handler.gd` (~140 lines)
+- `systems/input_modes/farming_mode_handler.gd` (~180 lines)
+- `systems/input_modes/look_mode_handler.gd` (~200 lines)
+
+### Modified Files
+- `systems/input_handler.gd` - Reduced from 2,569 to ~800 lines
+
+---
+
+## Verification Checklist
+
+After completing all changes:
+
+- [ ] Game launches without errors
+- [ ] Harvest mode (H key)
+  - [ ] Direction prompt appears
+  - [ ] WASD selects direction
+  - [ ] Continuous harvesting works
+  - [ ] Escape cancels
+- [ ] Fishing mode (F key near water)
+  - [ ] Direction prompt appears
+  - [ ] Continuous fishing works
+  - [ ] Escape cancels
+- [ ] Tilling mode (Shift+T)
+  - [ ] Direction prompt appears
+  - [ ] Tilled ground created
+- [ ] Planting mode (Shift+P with seeds)
+  - [ ] Direction prompt appears
+  - [ ] Tab cycles seeds
+  - [ ] Plant is created
+- [ ] Look mode (L key)
+  - [ ] Objects listed
+  - [ ] Tab cycles through objects
+  - [ ] Descriptions shown
+  - [ ] Escape exits
+- [ ] All modes cancel properly with Escape
+- [ ] Turn advances correctly for each action
+- [ ] No new console warnings/errors
+
+---
+
+## Rollback
+
+If issues occur:
+```bash
+rm -rf systems/input_modes/
+git checkout HEAD -- systems/input_handler.gd
+```
+
+Or revert entire commit:
+```bash
+git revert HEAD
+```

--- a/plans/features/v1.7/refactor-06-debug-command-executor.md
+++ b/plans/features/v1.7/refactor-06-debug-command-executor.md
@@ -1,0 +1,464 @@
+# Refactor 06: Debug Command Executor
+
+**Risk Level**: Low
+**Estimated Changes**: 1 new file, 1 file significantly reduced
+
+---
+
+## Goal
+
+Separate command execution logic from UI rendering in `debug_command_menu.gd` (2,203 lines).
+
+Extract all `_do_*` methods (command execution) into a `DebugCommandExecutor` class, leaving the menu as pure UI.
+
+---
+
+## Current State
+
+### debug_command_menu.gd
+The file mixes:
+- Tab container/menu UI management
+- Navigation and input handling
+- Command execution methods (`_do_give_gold()`, `_do_spawn_enemy()`, etc.)
+
+### Methods to Extract
+All methods that actually execute debug commands:
+- `_do_give_gold(amount)`
+- `_do_set_level(level)`
+- `_do_set_health(hp, max_hp)`
+- `_do_set_mana(mp, max_mp)`
+- `_do_set_stamina(sp, max_sp)`
+- `_do_modify_stat(stat_name, value)`
+- `_do_modify_skill(skill_name, value)`
+- `_do_spawn_enemy(enemy_id, position)`
+- `_do_spawn_hazard(hazard_id, position)`
+- `_do_spawn_feature(feature_id, position)`
+- `_do_give_item(item_id, quantity)`
+- `_do_teleport_to(position)`
+- `_do_set_time(hour, minute)`
+- `_do_set_date(day, month, year)`
+- `_do_set_weather(weather_type)`
+- `_do_set_season(season)`
+- `_do_reveal_map()`
+- `_do_toggle_god_mode()`
+- And similar execution methods...
+
+---
+
+## Implementation
+
+### Step 1: Create systems/debug_command_executor.gd
+
+```gdscript
+class_name DebugCommandExecutor
+extends RefCounted
+
+## DebugCommandExecutor - Executes debug commands
+##
+## Separated from DebugCommandMenu to isolate command logic from UI.
+## All methods are static for easy access without needing an instance.
+
+
+# =============================================================================
+# CURRENCY AND RESOURCES
+# =============================================================================
+
+## Give gold to the player
+static func give_gold(player: Player, amount: int) -> Dictionary:
+	if player == null:
+		return {"success": false, "message": "No player"}
+
+	player.gold += amount
+	EventBus.gold_changed.emit(player.gold)
+	return {"success": true, "message": "Gave %d gold (total: %d)" % [amount, player.gold]}
+
+
+## Set player gold to exact amount
+static func set_gold(player: Player, amount: int) -> Dictionary:
+	if player == null:
+		return {"success": false, "message": "No player"}
+
+	player.gold = amount
+	EventBus.gold_changed.emit(player.gold)
+	return {"success": true, "message": "Set gold to %d" % amount}
+
+
+# =============================================================================
+# PLAYER STATS
+# =============================================================================
+
+## Set player level
+static func set_level(player: Player, level: int) -> Dictionary:
+	if player == null:
+		return {"success": false, "message": "No player"}
+
+	level = clampi(level, 1, 50)
+	player.level = level
+	EventBus.player_leveled_up.emit(level)
+	return {"success": true, "message": "Set level to %d" % level}
+
+
+## Set player health
+static func set_health(player: Player, current: int, maximum: int = -1) -> Dictionary:
+	if player == null:
+		return {"success": false, "message": "No player"}
+
+	if maximum > 0:
+		player.max_hp = maximum
+	player.hp = mini(current, player.max_hp)
+	EventBus.player_health_changed.emit(player.hp, player.max_hp)
+	return {"success": true, "message": "Set HP to %d/%d" % [player.hp, player.max_hp]}
+
+
+## Set player mana
+static func set_mana(player: Player, current: int, maximum: int = -1) -> Dictionary:
+	if player == null:
+		return {"success": false, "message": "No player"}
+
+	if maximum > 0:
+		player.max_mp = maximum
+	player.mp = mini(current, player.max_mp)
+	EventBus.player_mana_changed.emit(player.mp, player.max_mp)
+	return {"success": true, "message": "Set MP to %d/%d" % [player.mp, player.max_mp]}
+
+
+## Set player stamina
+static func set_stamina(player: Player, current: int, maximum: int = -1) -> Dictionary:
+	if player == null:
+		return {"success": false, "message": "No player"}
+
+	if maximum > 0:
+		player.max_stamina = maximum
+	player.stamina = mini(current, player.max_stamina)
+	EventBus.player_stamina_changed.emit(player.stamina, player.max_stamina)
+	return {"success": true, "message": "Set Stamina to %d/%d" % [player.stamina, player.max_stamina]}
+
+
+## Modify an attribute
+static func modify_attribute(player: Player, attr_name: String, value: int) -> Dictionary:
+	if player == null:
+		return {"success": false, "message": "No player"}
+
+	if not attr_name in player.attributes:
+		return {"success": false, "message": "Unknown attribute: %s" % attr_name}
+
+	player.attributes[attr_name] = value
+	EventBus.player_stats_changed.emit()
+	return {"success": true, "message": "Set %s to %d" % [attr_name, value]}
+
+
+## Modify a skill
+static func modify_skill(player: Player, skill_name: String, value: int) -> Dictionary:
+	if player == null:
+		return {"success": false, "message": "No player"}
+
+	if not skill_name in player.skills:
+		return {"success": false, "message": "Unknown skill: %s" % skill_name}
+
+	player.skills[skill_name] = value
+	EventBus.player_stats_changed.emit()
+	return {"success": true, "message": "Set %s to %d" % [skill_name, value]}
+
+
+# =============================================================================
+# SPAWNING
+# =============================================================================
+
+## Spawn an enemy at position (or near player if position is ZERO)
+static func spawn_enemy(enemy_id: String, position: Vector2i = Vector2i.ZERO) -> Dictionary:
+	var definition = EntityManager.get_enemy_definition(enemy_id)
+	if definition == null:
+		return {"success": false, "message": "Unknown enemy: %s" % enemy_id}
+
+	var spawn_pos = position
+	if spawn_pos == Vector2i.ZERO:
+		# Spawn near player
+		var player = EntityManager.player
+		if player:
+			spawn_pos = _find_nearby_empty_position(player.position)
+
+	if spawn_pos == Vector2i.ZERO:
+		return {"success": false, "message": "No valid spawn position"}
+
+	var enemy = EntityManager.spawn_enemy(enemy_id, spawn_pos)
+	if enemy:
+		return {"success": true, "message": "Spawned %s at %s" % [enemy_id, spawn_pos]}
+	return {"success": false, "message": "Failed to spawn enemy"}
+
+
+## Spawn a hazard at position
+static func spawn_hazard(hazard_id: String, position: Vector2i) -> Dictionary:
+	var result = HazardManager.place_hazard(hazard_id, position)
+	if result:
+		return {"success": true, "message": "Placed %s at %s" % [hazard_id, position]}
+	return {"success": false, "message": "Failed to place hazard"}
+
+
+## Spawn a feature at position
+static func spawn_feature(feature_id: String, position: Vector2i) -> Dictionary:
+	var result = FeatureManager.place_feature(feature_id, position)
+	if result:
+		return {"success": true, "message": "Placed %s at %s" % [feature_id, position]}
+	return {"success": false, "message": "Failed to place feature"}
+
+
+# =============================================================================
+# ITEMS
+# =============================================================================
+
+## Give item to player
+static func give_item(player: Player, item_id: String, quantity: int = 1) -> Dictionary:
+	if player == null:
+		return {"success": false, "message": "No player"}
+
+	var item = ItemManager.create_item(item_id)
+	if item == null:
+		return {"success": false, "message": "Unknown item: %s" % item_id}
+
+	if item.stackable:
+		item.stack_count = quantity
+
+	var added = player.inventory.add_item(item)
+	if added:
+		EventBus.inventory_changed.emit()
+		return {"success": true, "message": "Gave %dx %s" % [quantity, item.display_name]}
+	return {"success": false, "message": "Inventory full"}
+
+
+## Clear player inventory
+static func clear_inventory(player: Player) -> Dictionary:
+	if player == null:
+		return {"success": false, "message": "No player"}
+
+	var count = player.inventory.items.size()
+	player.inventory.items.clear()
+	EventBus.inventory_changed.emit()
+	return {"success": true, "message": "Cleared %d items" % count}
+
+
+# =============================================================================
+# TELEPORTATION
+# =============================================================================
+
+## Teleport player to position
+static func teleport_to(player: Player, position: Vector2i) -> Dictionary:
+	if player == null:
+		return {"success": false, "message": "No player"}
+
+	player.position = position
+	EventBus.player_moved.emit(position)
+	return {"success": true, "message": "Teleported to %s" % position}
+
+
+## Teleport player to town
+static func teleport_to_town(player: Player) -> Dictionary:
+	var town_pos = TownManager.get_town_center()
+	if town_pos == Vector2i.ZERO:
+		return {"success": false, "message": "No town found"}
+	return teleport_to(player, town_pos)
+
+
+## Teleport player to dungeon entrance
+static func teleport_to_dungeon(player: Player, dungeon_id: String = "") -> Dictionary:
+	var entrance = DungeonManager.get_nearest_entrance(player.position if player else Vector2i.ZERO)
+	if entrance == Vector2i.ZERO:
+		return {"success": false, "message": "No dungeon entrance found"}
+	return teleport_to(player, entrance)
+
+
+# =============================================================================
+# TIME AND WEATHER
+# =============================================================================
+
+## Set game time
+static func set_time(hour: int, minute: int = 0) -> Dictionary:
+	hour = clampi(hour, 0, 23)
+	minute = clampi(minute, 0, 59)
+	CalendarManager.set_time(hour, minute)
+	return {"success": true, "message": "Set time to %02d:%02d" % [hour, minute]}
+
+
+## Set game date
+static func set_date(day: int, month: int, year: int) -> Dictionary:
+	CalendarManager.set_date(day, month, year)
+	return {"success": true, "message": "Set date to %d/%d/%d" % [day, month, year]}
+
+
+## Set weather
+static func set_weather(weather_type: String) -> Dictionary:
+	WeatherManager.set_weather(weather_type)
+	return {"success": true, "message": "Set weather to %s" % weather_type}
+
+
+## Set season
+static func set_season(season: String) -> Dictionary:
+	CalendarManager.set_season(season)
+	return {"success": true, "message": "Set season to %s" % season}
+
+
+# =============================================================================
+# MAP AND VISIBILITY
+# =============================================================================
+
+## Reveal entire map
+static func reveal_map() -> Dictionary:
+	if MapManager.current_map:
+		MapManager.current_map.reveal_all()
+		return {"success": true, "message": "Map revealed"}
+	return {"success": false, "message": "No current map"}
+
+
+## Toggle fog of war
+static func toggle_fog_of_war(enabled: bool) -> Dictionary:
+	GameConfig.fog_of_war_enabled = enabled
+	return {"success": true, "message": "Fog of war %s" % ("enabled" if enabled else "disabled")}
+
+
+# =============================================================================
+# CHEAT MODES
+# =============================================================================
+
+## Toggle god mode (invincibility)
+static func toggle_god_mode(player: Player) -> Dictionary:
+	if player == null:
+		return {"success": false, "message": "No player"}
+
+	player.god_mode = not player.god_mode
+	return {"success": true, "message": "God mode %s" % ("enabled" if player.god_mode else "disabled")}
+
+
+## Toggle no-clip mode
+static func toggle_noclip(player: Player) -> Dictionary:
+	if player == null:
+		return {"success": false, "message": "No player"}
+
+	player.noclip = not player.noclip
+	return {"success": true, "message": "No-clip %s" % ("enabled" if player.noclip else "disabled")}
+
+
+## Full heal player
+static func full_heal(player: Player) -> Dictionary:
+	if player == null:
+		return {"success": false, "message": "No player"}
+
+	player.hp = player.max_hp
+	player.mp = player.max_mp
+	player.stamina = player.max_stamina
+	EventBus.player_health_changed.emit(player.hp, player.max_hp)
+	EventBus.player_mana_changed.emit(player.mp, player.max_mp)
+	EventBus.player_stamina_changed.emit(player.stamina, player.max_stamina)
+	return {"success": true, "message": "Fully healed"}
+
+
+# =============================================================================
+# HELPERS
+# =============================================================================
+
+## Find an empty position near the given position
+static func _find_nearby_empty_position(center: Vector2i, max_radius: int = 5) -> Vector2i:
+	var map = MapManager.current_map
+	if map == null:
+		return Vector2i.ZERO
+
+	for radius in range(1, max_radius + 1):
+		for dx in range(-radius, radius + 1):
+			for dy in range(-radius, radius + 1):
+				var pos = center + Vector2i(dx, dy)
+				if map.is_walkable(pos) and not EntityManager.get_entity_at(pos):
+					return pos
+
+	return Vector2i.ZERO
+```
+
+---
+
+### Step 2: Update ui/debug_command_menu.gd
+
+1. **Add preload** at top:
+```gdscript
+const DebugCommandExecutorClass = preload("res://systems/debug_command_executor.gd")
+```
+
+2. **Replace `_do_*` method calls** with executor calls:
+
+```gdscript
+# Before:
+func _on_give_gold_confirmed(amount: int) -> void:
+	_do_give_gold(amount)
+	_show_confirmation("Gave %d gold" % amount)
+
+func _do_give_gold(amount: int) -> void:
+	if player:
+		player.gold += amount
+		EventBus.gold_changed.emit(player.gold)
+
+# After:
+func _on_give_gold_confirmed(amount: int) -> void:
+	var result = DebugCommandExecutorClass.give_gold(player, amount)
+	_show_confirmation(result.message)
+```
+
+3. **Remove all `_do_*` methods** - they're now in the executor.
+
+4. **Update all command handlers** to use the executor pattern.
+
+---
+
+## Files Summary
+
+### New Files
+- `systems/debug_command_executor.gd` (~300 lines)
+
+### Modified Files
+- `ui/debug_command_menu.gd` - Reduced from 2,203 to ~800 lines
+
+---
+
+## Verification Checklist
+
+After completing all changes:
+
+- [ ] Game launches without errors
+- [ ] Open debug menu (F12)
+- [ ] Test gold commands
+  - [ ] Give gold
+  - [ ] Set gold
+- [ ] Test stat commands
+  - [ ] Set level
+  - [ ] Set HP/MP/Stamina
+  - [ ] Modify attributes
+  - [ ] Modify skills
+- [ ] Test spawn commands
+  - [ ] Spawn enemy
+  - [ ] Spawn hazard
+  - [ ] Spawn feature
+- [ ] Test item commands
+  - [ ] Give item
+  - [ ] Clear inventory
+- [ ] Test teleport commands
+  - [ ] Teleport to position
+  - [ ] Teleport to town
+- [ ] Test time/weather commands
+  - [ ] Set time
+  - [ ] Set date
+  - [ ] Set weather
+  - [ ] Set season
+- [ ] Test cheat modes
+  - [ ] God mode toggle
+  - [ ] Reveal map
+- [ ] No new console warnings/errors
+
+---
+
+## Rollback
+
+If issues occur:
+```bash
+git checkout HEAD -- ui/debug_command_menu.gd
+rm systems/debug_command_executor.gd
+```
+
+Or revert entire commit:
+```bash
+git revert HEAD
+```

--- a/plans/features/v1.7/refactor-07-item-usage-handler.md
+++ b/plans/features/v1.7/refactor-07-item-usage-handler.md
@@ -1,0 +1,511 @@
+# Refactor 07: Item Usage Handler
+
+**Risk Level**: Medium
+**Estimated Changes**: 1 new file, 2 files modified
+
+---
+
+## Goal
+
+Separate item usage logic from the `Item` class data structure.
+
+Extract `use()`, `apply_effects()`, and related methods into an `ItemUsageHandler` class, keeping `Item` as a pure data container.
+
+---
+
+## Current State
+
+### items/item.gd (1,170 lines)
+The Item class mixes:
+- Data properties (id, name, type, stats, etc.) - ~120 lines
+- Factory method `create_from_data()` - ~200 lines
+- Usage logic `use()` - ~150 lines with extensive branching
+- Effect application `apply_effects()`, `apply_passive_effects()` - ~100 lines
+- Spell/ritual learning - ~50 lines
+- Equipment mechanics - ~100 lines
+- Stack management - ~50 lines
+- Serialization - ~100 lines
+
+### Methods to Extract
+- `use(user: Entity) -> Dictionary` - Main usage logic
+- `apply_effects(user: Entity)` - Apply consumable effects
+- `apply_passive_effects(user: Entity)` - Apply equipped item effects
+- `remove_passive_effects(user: Entity)` - Remove equipped item effects
+- `try_learn_spell(user: Entity)` - Learn spell from book/scroll
+- `try_learn_ritual(user: Entity)` - Learn ritual from item
+- `try_learn_recipe(user: Entity)` - Learn recipe from book
+
+---
+
+## Implementation
+
+### Step 1: Create items/item_usage_handler.gd
+
+```gdscript
+class_name ItemUsageHandler
+extends RefCounted
+
+## ItemUsageHandler - Handles item usage, effects, and learning
+##
+## Extracted from Item class to separate data from behavior.
+## All methods are static for easy access.
+
+const SpellCastingSystemClass = preload("res://systems/spell_casting_system.gd")
+const RitualSystemClass = preload("res://systems/ritual_system.gd")
+
+
+# =============================================================================
+# MAIN USAGE
+# =============================================================================
+
+## Use an item, returning result dictionary
+## Result: {"success": bool, "message": String, "consumed": bool}
+static func use(item: Item, user: Entity) -> Dictionary:
+	if item == null or user == null:
+		return {"success": false, "message": "Invalid item or user", "consumed": false}
+
+	match item.item_type:
+		"consumable", "food", "potion", "bandage":
+			return _use_consumable(item, user)
+		"scroll":
+			return _use_scroll(item, user)
+		"wand":
+			return _use_wand(item, user)
+		"book":
+			return _use_book(item, user)
+		"ritual_item":
+			return _use_ritual_item(item, user)
+		"tool":
+			return _use_tool(item, user)
+		"key":
+			return _use_key(item, user)
+		_:
+			if item.is_equippable():
+				return {"success": false, "message": "Use equipment screen to equip this item", "consumed": false}
+			return {"success": false, "message": "Cannot use this item", "consumed": false}
+
+
+# =============================================================================
+# CONSUMABLES
+# =============================================================================
+
+## Use a consumable item (food, potion, bandage)
+static func _use_consumable(item: Item, user: Entity) -> Dictionary:
+	# Check if user can benefit from the item
+	if item.item_type == "food":
+		if user.has_method("get_hunger") and user.get_hunger() <= 0:
+			return {"success": false, "message": "You're not hungry", "consumed": false}
+
+	# Apply effects
+	var effects_applied = apply_effects(item, user)
+
+	if effects_applied:
+		# Consume the item
+		return {"success": true, "message": "Used %s" % item.display_name, "consumed": true}
+
+	return {"success": false, "message": "Item had no effect", "consumed": false}
+
+
+## Apply item effects to user
+static func apply_effects(item: Item, user: Entity) -> bool:
+	if item == null or user == null:
+		return false
+
+	var had_effect = false
+
+	# Healing
+	if item.healing > 0 and user.hp < user.max_hp:
+		var heal_amount = mini(item.healing, user.max_hp - user.hp)
+		user.hp += heal_amount
+		EventBus.player_health_changed.emit(user.hp, user.max_hp)
+		EventBus.message_logged.emit("Healed %d HP" % heal_amount)
+		had_effect = true
+
+	# Mana restoration
+	if item.mana_restore > 0 and user.mp < user.max_mp:
+		var restore_amount = mini(item.mana_restore, user.max_mp - user.mp)
+		user.mp += restore_amount
+		EventBus.player_mana_changed.emit(user.mp, user.max_mp)
+		EventBus.message_logged.emit("Restored %d MP" % restore_amount)
+		had_effect = true
+
+	# Stamina restoration
+	if item.stamina_restore > 0 and user.stamina < user.max_stamina:
+		var restore_amount = mini(item.stamina_restore, user.max_stamina - user.stamina)
+		user.stamina += restore_amount
+		EventBus.player_stamina_changed.emit(user.stamina, user.max_stamina)
+		EventBus.message_logged.emit("Restored %d Stamina" % restore_amount)
+		had_effect = true
+
+	# Food (hunger reduction)
+	if item.nutrition > 0 and user.has_method("reduce_hunger"):
+		user.reduce_hunger(item.nutrition)
+		had_effect = true
+
+	# Hydration
+	if item.hydration > 0 and user.has_method("reduce_thirst"):
+		user.reduce_thirst(item.hydration)
+		had_effect = true
+
+	# Status effect removal
+	if item.cures_poison and user.has_method("cure_poison"):
+		user.cure_poison()
+		had_effect = true
+
+	if item.cures_disease and user.has_method("cure_disease"):
+		user.cure_disease()
+		had_effect = true
+
+	# Buff effects
+	if item.buffs and not item.buffs.is_empty():
+		_apply_buffs(item.buffs, user)
+		had_effect = true
+
+	return had_effect
+
+
+## Apply buff effects from item
+static func _apply_buffs(buffs: Dictionary, user: Entity) -> void:
+	for buff_id in buffs:
+		var buff_data = buffs[buff_id]
+		if user.has_method("add_buff"):
+			user.add_buff(buff_id, buff_data)
+
+
+# =============================================================================
+# SCROLLS
+# =============================================================================
+
+## Use a scroll to cast a spell
+static func _use_scroll(item: Item, user: Entity) -> Dictionary:
+	if not item.spell_id or item.spell_id.is_empty():
+		return {"success": false, "message": "Scroll has no spell", "consumed": false}
+
+	var spell = SpellManager.get_spell(item.spell_id)
+	if spell == null:
+		return {"success": false, "message": "Unknown spell on scroll", "consumed": false}
+
+	# Check if spell needs targeting
+	if spell.needs_target:
+		# Trigger targeting mode - scroll consumed after successful cast
+		EventBus.scroll_targeting_started.emit(item, spell)
+		return {"success": true, "message": "Select target for %s" % spell.name, "consumed": false}
+
+	# Instant cast spell
+	var result = SpellCastingSystemClass.cast_spell(user, spell, user.position)
+	if result.success:
+		return {"success": true, "message": result.message, "consumed": true}
+
+	return {"success": false, "message": result.message, "consumed": false}
+
+
+# =============================================================================
+# WANDS
+# =============================================================================
+
+## Use a wand to cast a spell
+static func _use_wand(item: Item, user: Entity) -> Dictionary:
+	if not item.spell_id or item.spell_id.is_empty():
+		return {"success": false, "message": "Wand has no spell", "consumed": false}
+
+	if item.charges <= 0:
+		return {"success": false, "message": "Wand is out of charges", "consumed": false}
+
+	var spell = SpellManager.get_spell(item.spell_id)
+	if spell == null:
+		return {"success": false, "message": "Unknown spell on wand", "consumed": false}
+
+	# Check if spell needs targeting
+	if spell.needs_target:
+		EventBus.wand_targeting_started.emit(item, spell)
+		return {"success": true, "message": "Select target for %s" % spell.name, "consumed": false}
+
+	# Instant cast
+	var result = SpellCastingSystemClass.cast_spell(user, spell, user.position)
+	if result.success:
+		item.charges -= 1
+		if item.charges <= 0:
+			EventBus.message_logged.emit("The wand crumbles to dust!")
+			return {"success": true, "message": result.message, "consumed": true}
+		return {"success": true, "message": result.message, "consumed": false}
+
+	return {"success": false, "message": result.message, "consumed": false}
+
+
+# =============================================================================
+# BOOKS
+# =============================================================================
+
+## Use a book to learn spells/recipes
+static func _use_book(item: Item, user: Entity) -> Dictionary:
+	# Recipe book
+	if item.teaches_recipe and not item.teaches_recipe.is_empty():
+		return _try_learn_recipe(item, user)
+
+	# Spell book
+	if item.teaches_spell and not item.teaches_spell.is_empty():
+		return _try_learn_spell(item, user)
+
+	return {"success": false, "message": "This book contains nothing useful", "consumed": false}
+
+
+## Try to learn a spell from item
+static func _try_learn_spell(item: Item, user: Entity) -> Dictionary:
+	if not user.has_method("learn_spell"):
+		return {"success": false, "message": "Cannot learn spells", "consumed": false}
+
+	var spell_id = item.teaches_spell
+	if user.knows_spell(spell_id):
+		return {"success": false, "message": "You already know this spell", "consumed": false}
+
+	var spell = SpellManager.get_spell(spell_id)
+	if spell == null:
+		return {"success": false, "message": "Unknown spell", "consumed": false}
+
+	# Check requirements (level, stats, etc.)
+	if not _meets_spell_requirements(spell, user):
+		return {"success": false, "message": "You don't meet the requirements to learn this spell", "consumed": false}
+
+	user.learn_spell(spell_id)
+	return {"success": true, "message": "Learned %s!" % spell.name, "consumed": true}
+
+
+## Try to learn a recipe from item
+static func _try_learn_recipe(item: Item, user: Entity) -> Dictionary:
+	if not user.has_method("learn_recipe"):
+		return {"success": false, "message": "Cannot learn recipes", "consumed": false}
+
+	var recipe_id = item.teaches_recipe
+	if user.knows_recipe(recipe_id):
+		return {"success": false, "message": "You already know this recipe", "consumed": false}
+
+	var recipe = RecipeManager.get_recipe(recipe_id)
+	if recipe == null:
+		return {"success": false, "message": "Unknown recipe", "consumed": false}
+
+	user.learn_recipe(recipe_id)
+	return {"success": true, "message": "Learned recipe: %s!" % recipe.name, "consumed": true}
+
+
+## Check if user meets spell requirements
+static func _meets_spell_requirements(spell: Dictionary, user: Entity) -> bool:
+	# Level requirement
+	if spell.has("min_level") and user.level < spell.min_level:
+		return false
+
+	# Stat requirements
+	if spell.has("required_int") and user.attributes.get("INT", 0) < spell.required_int:
+		return false
+
+	if spell.has("required_wis") and user.attributes.get("WIS", 0) < spell.required_wis:
+		return false
+
+	return true
+
+
+# =============================================================================
+# RITUAL ITEMS
+# =============================================================================
+
+## Use a ritual item
+static func _use_ritual_item(item: Item, user: Entity) -> Dictionary:
+	if not item.teaches_ritual or item.teaches_ritual.is_empty():
+		return {"success": false, "message": "This item teaches no ritual", "consumed": false}
+
+	if not user.has_method("learn_ritual"):
+		return {"success": false, "message": "Cannot learn rituals", "consumed": false}
+
+	var ritual_id = item.teaches_ritual
+	if user.knows_ritual(ritual_id):
+		return {"success": false, "message": "You already know this ritual", "consumed": false}
+
+	user.learn_ritual(ritual_id)
+	var ritual = RitualManager.get_ritual(ritual_id)
+	var ritual_name = ritual.name if ritual else ritual_id
+	return {"success": true, "message": "Learned ritual: %s!" % ritual_name, "consumed": true}
+
+
+# =============================================================================
+# TOOLS
+# =============================================================================
+
+## Use a tool item
+static func _use_tool(item: Item, user: Entity) -> Dictionary:
+	# Tools are typically used implicitly (fishing rod when fishing, etc.)
+	return {"success": false, "message": "Use this tool with the appropriate action", "consumed": false}
+
+
+# =============================================================================
+# KEYS
+# =============================================================================
+
+## Use a key item
+static func _use_key(item: Item, user: Entity) -> Dictionary:
+	# Keys are used automatically when interacting with locked things
+	return {"success": false, "message": "Use this key by interacting with a locked object", "consumed": false}
+
+
+# =============================================================================
+# EQUIPMENT EFFECTS
+# =============================================================================
+
+## Apply passive effects when item is equipped
+static func apply_equipment_effects(item: Item, user: Entity) -> void:
+	if item == null or user == null:
+		return
+
+	# Stat bonuses
+	if item.stat_bonuses:
+		for stat in item.stat_bonuses:
+			if stat in user.attributes:
+				user.attribute_bonuses[stat] = user.attribute_bonuses.get(stat, 0) + item.stat_bonuses[stat]
+
+	# Armor
+	if item.armor > 0:
+		user.armor_bonus += item.armor
+
+	# Damage bonus
+	if item.damage_bonus > 0:
+		user.damage_bonus += item.damage_bonus
+
+	# Recalculate derived stats
+	if user.has_method("recalculate_stats"):
+		user.recalculate_stats()
+
+
+## Remove passive effects when item is unequipped
+static func remove_equipment_effects(item: Item, user: Entity) -> void:
+	if item == null or user == null:
+		return
+
+	# Stat bonuses
+	if item.stat_bonuses:
+		for stat in item.stat_bonuses:
+			if stat in user.attribute_bonuses:
+				user.attribute_bonuses[stat] = user.attribute_bonuses.get(stat, 0) - item.stat_bonuses[stat]
+
+	# Armor
+	if item.armor > 0:
+		user.armor_bonus -= item.armor
+
+	# Damage bonus
+	if item.damage_bonus > 0:
+		user.damage_bonus -= item.damage_bonus
+
+	# Recalculate derived stats
+	if user.has_method("recalculate_stats"):
+		user.recalculate_stats()
+```
+
+---
+
+### Step 2: Update items/item.gd
+
+1. **Add preload** at top:
+```gdscript
+const ItemUsageHandlerClass = preload("res://items/item_usage_handler.gd")
+```
+
+2. **Simplify `use()` method**:
+```gdscript
+## Use this item
+func use(user: Entity) -> Dictionary:
+	return ItemUsageHandlerClass.use(self, user)
+```
+
+3. **Remove** the following methods (now in handler):
+- Large `use()` implementation with match statement
+- `_use_consumable()`, `_use_scroll()`, `_use_wand()`, etc.
+- `apply_effects()`
+- `_apply_buffs()`
+- `_try_learn_spell()`, `_try_learn_recipe()`, `_try_learn_ritual()`
+- `_meets_spell_requirements()`
+
+4. **Update equipment effect methods** to delegate:
+```gdscript
+func apply_passive_effects(user: Entity) -> void:
+	ItemUsageHandlerClass.apply_equipment_effects(self, user)
+
+func remove_passive_effects(user: Entity) -> void:
+	ItemUsageHandlerClass.remove_equipment_effects(self, user)
+```
+
+---
+
+### Step 3: Update systems/inventory_system.gd
+
+Ensure item usage goes through the handler:
+
+```gdscript
+## Use an item from inventory
+func use_item(item: Item, user: Entity) -> Dictionary:
+	var result = ItemUsageHandlerClass.use(item, user)
+
+	if result.consumed:
+		# Remove or reduce stack
+		if item.stackable and item.stack_count > 1:
+			item.stack_count -= 1
+		else:
+			remove_item(item)
+		EventBus.inventory_changed.emit()
+
+	return result
+```
+
+---
+
+## Files Summary
+
+### New Files
+- `items/item_usage_handler.gd` (~350 lines)
+
+### Modified Files
+- `items/item.gd` - Reduced from 1,170 to ~600 lines
+- `systems/inventory_system.gd` - Minor updates
+
+---
+
+## Verification Checklist
+
+After completing all changes:
+
+- [ ] Game launches without errors
+- [ ] Use consumable items
+  - [ ] Food reduces hunger
+  - [ ] Potions heal
+  - [ ] Bandages work
+- [ ] Use scrolls
+  - [ ] Instant spells cast
+  - [ ] Targeted spells enter targeting mode
+  - [ ] Scroll consumed after successful cast
+- [ ] Use wands
+  - [ ] Charges decrease
+  - [ ] Wand destroyed at 0 charges
+- [ ] Use books
+  - [ ] Learn recipes
+  - [ ] Learn spells
+- [ ] Equipment effects
+  - [ ] Equipping adds stat bonuses
+  - [ ] Unequipping removes stat bonuses
+- [ ] Stack management
+  - [ ] Using stacked items decreases count
+  - [ ] Item removed when stack depleted
+- [ ] Save and load
+  - [ ] Item usage state preserved
+- [ ] No new console warnings/errors
+
+---
+
+## Rollback
+
+If issues occur:
+```bash
+git checkout HEAD -- items/item.gd
+git checkout HEAD -- systems/inventory_system.gd
+rm items/item_usage_handler.gd
+```
+
+Or revert entire commit:
+```bash
+git revert HEAD
+```

--- a/plans/features/v1.7/refactor-08-save-serializers.md
+++ b/plans/features/v1.7/refactor-08-save-serializers.md
@@ -1,0 +1,786 @@
+# Refactor 08: Save Serializers
+
+**Risk Level**: Medium
+**Estimated Changes**: 4 new files, 1 file significantly reduced
+
+---
+
+## Goal
+
+Extract domain-specific serialization from `save_manager.gd` (1,117 lines) into separate serializer classes:
+- PlayerSerializer
+- EntitySerializer
+- MapSerializer
+- InventorySerializer
+
+SaveManager becomes a coordinator that orchestrates the serializers.
+
+---
+
+## Current State
+
+### autoload/save_manager.gd
+Contains 14+ `_serialize_*` and `_deserialize_*` method pairs:
+- `_serialize_player()` / `_deserialize_player()`
+- `_serialize_survival()` / `_deserialize_survival()`
+- `_serialize_inventory()` / `_deserialize_inventory()`
+- `_serialize_equipment()` / `_deserialize_equipment()`
+- `_serialize_entities()` / `_deserialize_entities()`
+- `_serialize_enemy()` / `_deserialize_enemy()`
+- `_serialize_npc()` / `_deserialize_npc()`
+- `_serialize_map_state()` / `_deserialize_map_state()`
+- `_serialize_features()` / `_deserialize_features()`
+- `_serialize_hazards()` / `_deserialize_hazards()`
+- `_serialize_ground_items()` / `_deserialize_ground_items()`
+- And more...
+
+---
+
+## Implementation
+
+### Step 1: Create autoload/serializers/ Directory
+
+```bash
+mkdir -p autoload/serializers
+```
+
+---
+
+### Step 2: Create autoload/serializers/player_serializer.gd
+
+```gdscript
+class_name PlayerSerializer
+extends RefCounted
+
+## PlayerSerializer - Handles player state serialization
+##
+## Serializes/deserializes player attributes, stats, skills, spells, rituals, etc.
+
+
+## Serialize complete player state to dictionary
+static func serialize(player: Player) -> Dictionary:
+	if player == null:
+		return {}
+
+	return {
+		"position": {"x": player.position.x, "y": player.position.y},
+		"level": player.level,
+		"experience": player.experience,
+		"gold": player.gold,
+		"hp": player.hp,
+		"max_hp": player.max_hp,
+		"mp": player.mp,
+		"max_mp": player.max_mp,
+		"stamina": player.stamina,
+		"max_stamina": player.max_stamina,
+		"attributes": player.attributes.duplicate(),
+		"attribute_bonuses": player.attribute_bonuses.duplicate(),
+		"skills": player.skills.duplicate(),
+		"known_spells": player.known_spells.duplicate(),
+		"known_rituals": player.known_rituals.duplicate(),
+		"known_recipes": player.known_recipes.duplicate(),
+		"racial_abilities": player.racial_abilities.duplicate() if player.racial_abilities else [],
+		"class_feats": player.class_feats.duplicate() if player.class_feats else [],
+		"race_id": player.race_id,
+		"class_id": player.class_id,
+		"god_mode": player.god_mode if "god_mode" in player else false,
+		"death_count": player.death_count if "death_count" in player else 0,
+		"survival": _serialize_survival(player),
+		"active_effects": _serialize_active_effects(player),
+		"concentration": _serialize_concentration(player),
+		"summons": _serialize_summons(player),
+	}
+
+
+## Deserialize player state from dictionary
+static func deserialize(player: Player, data: Dictionary) -> void:
+	if player == null or data.is_empty():
+		return
+
+	# Position
+	if "position" in data:
+		player.position = Vector2i(data.position.x, data.position.y)
+
+	# Core stats
+	player.level = data.get("level", 1)
+	player.experience = data.get("experience", 0)
+	player.gold = data.get("gold", 0)
+	player.hp = data.get("hp", player.max_hp)
+	player.max_hp = data.get("max_hp", 100)
+	player.mp = data.get("mp", player.max_mp)
+	player.max_mp = data.get("max_mp", 50)
+	player.stamina = data.get("stamina", player.max_stamina)
+	player.max_stamina = data.get("max_stamina", 100)
+
+	# Attributes and skills
+	if "attributes" in data:
+		player.attributes = data.attributes.duplicate()
+	if "attribute_bonuses" in data:
+		player.attribute_bonuses = data.attribute_bonuses.duplicate()
+	if "skills" in data:
+		player.skills = data.skills.duplicate()
+
+	# Knowledge
+	if "known_spells" in data:
+		player.known_spells = data.known_spells.duplicate()
+	if "known_rituals" in data:
+		player.known_rituals = data.known_rituals.duplicate()
+	if "known_recipes" in data:
+		player.known_recipes = data.known_recipes.duplicate()
+
+	# Race and class
+	player.race_id = data.get("race_id", "")
+	player.class_id = data.get("class_id", "")
+	if "racial_abilities" in data:
+		player.racial_abilities = data.racial_abilities.duplicate()
+	if "class_feats" in data:
+		player.class_feats = data.class_feats.duplicate()
+
+	# Misc
+	if "god_mode" in data:
+		player.god_mode = data.god_mode
+	if "death_count" in data:
+		player.death_count = data.death_count
+
+	# Survival
+	if "survival" in data:
+		_deserialize_survival(player, data.survival)
+
+	# Active effects
+	if "active_effects" in data:
+		_deserialize_active_effects(player, data.active_effects)
+
+	# Concentration
+	if "concentration" in data:
+		_deserialize_concentration(player, data.concentration)
+
+	# Summons
+	if "summons" in data:
+		_deserialize_summons(player, data.summons)
+
+
+## Serialize survival state
+static func _serialize_survival(player: Player) -> Dictionary:
+	return {
+		"hunger": player.hunger if "hunger" in player else 0,
+		"thirst": player.thirst if "thirst" in player else 0,
+		"temperature": player.temperature if "temperature" in player else 20.0,
+		"wetness": player.wetness if "wetness" in player else 0.0,
+	}
+
+
+## Deserialize survival state
+static func _deserialize_survival(player: Player, data: Dictionary) -> void:
+	if "hunger" in data and "hunger" in player:
+		player.hunger = data.hunger
+	if "thirst" in data and "thirst" in player:
+		player.thirst = data.thirst
+	if "temperature" in data and "temperature" in player:
+		player.temperature = data.temperature
+	if "wetness" in data and "wetness" in player:
+		player.wetness = data.wetness
+
+
+## Serialize active effects/buffs
+static func _serialize_active_effects(player: Player) -> Array:
+	var effects: Array = []
+	if player.has_method("get_active_effects"):
+		for effect in player.get_active_effects():
+			effects.append({
+				"id": effect.id,
+				"duration": effect.duration,
+				"strength": effect.strength if "strength" in effect else 1,
+			})
+	return effects
+
+
+## Deserialize active effects
+static func _deserialize_active_effects(player: Player, data: Array) -> void:
+	if not player.has_method("add_effect"):
+		return
+	for effect_data in data:
+		player.add_effect(effect_data.id, effect_data.get("duration", 0), effect_data.get("strength", 1))
+
+
+## Serialize concentration state
+static func _serialize_concentration(player: Player) -> Dictionary:
+	if not "concentration_spell" in player or player.concentration_spell == null:
+		return {}
+	return {
+		"spell_id": player.concentration_spell.id if player.concentration_spell else "",
+		"target_position": {
+			"x": player.concentration_target.x,
+			"y": player.concentration_target.y
+		} if player.concentration_target else null,
+	}
+
+
+## Deserialize concentration state
+static func _deserialize_concentration(player: Player, data: Dictionary) -> void:
+	if data.is_empty():
+		return
+	# Concentration is typically restored through spell re-casting on load
+	# Just store the spell ID for reference
+	if "spell_id" in data and data.spell_id != "":
+		player._pending_concentration_restore = data
+
+
+## Serialize summons
+static func _serialize_summons(player: Player) -> Array:
+	var summons: Array = []
+	if player.has_method("get_summons"):
+		for summon in player.get_summons():
+			summons.append({
+				"enemy_id": summon.enemy_id,
+				"position": {"x": summon.position.x, "y": summon.position.y},
+				"hp": summon.hp,
+				"max_hp": summon.max_hp,
+			})
+	return summons
+
+
+## Deserialize summons
+static func _deserialize_summons(player: Player, data: Array) -> void:
+	if not player.has_method("add_summon"):
+		return
+	for summon_data in data:
+		var summon = EntityManager.spawn_enemy(summon_data.enemy_id, Vector2i(summon_data.position.x, summon_data.position.y))
+		if summon:
+			summon.hp = summon_data.get("hp", summon.max_hp)
+			player.add_summon(summon)
+```
+
+---
+
+### Step 3: Create autoload/serializers/inventory_serializer.gd
+
+```gdscript
+class_name InventorySerializer
+extends RefCounted
+
+## InventorySerializer - Handles inventory and equipment serialization
+
+
+## Serialize complete inventory state
+static func serialize(inventory: Inventory) -> Dictionary:
+	if inventory == null:
+		return {}
+
+	return {
+		"items": _serialize_items(inventory.items),
+		"equipment": _serialize_equipment(inventory.equipment),
+		"max_weight": inventory.max_weight,
+	}
+
+
+## Deserialize inventory state
+static func deserialize(inventory: Inventory, data: Dictionary) -> void:
+	if inventory == null or data.is_empty():
+		return
+
+	# Clear existing
+	inventory.items.clear()
+	for slot in inventory.equipment:
+		inventory.equipment[slot] = null
+
+	# Load items
+	if "items" in data:
+		for item_data in data.items:
+			var item = _deserialize_item(item_data)
+			if item:
+				inventory.items.append(item)
+
+	# Load equipment
+	if "equipment" in data:
+		for slot in data.equipment:
+			var item_data = data.equipment[slot]
+			if item_data:
+				var item = _deserialize_item(item_data)
+				if item:
+					inventory.equipment[slot] = item
+
+	# Max weight
+	if "max_weight" in data:
+		inventory.max_weight = data.max_weight
+
+
+## Serialize array of items
+static func _serialize_items(items: Array) -> Array:
+	var result: Array = []
+	for item in items:
+		result.append(_serialize_item(item))
+	return result
+
+
+## Serialize single item
+static func _serialize_item(item: Item) -> Dictionary:
+	if item == null:
+		return {}
+
+	var data = {
+		"id": item.id,
+		"display_name": item.display_name,
+		"item_type": item.item_type,
+		"stack_count": item.stack_count,
+		"identified": item.identified,
+		"inscription": item.inscription if item.inscription else "",
+	}
+
+	# Equipment stats
+	if item.is_equippable():
+		data["damage"] = item.damage
+		data["armor"] = item.armor
+		data["stat_bonuses"] = item.stat_bonuses.duplicate() if item.stat_bonuses else {}
+
+	# Consumable properties
+	if item.item_type in ["consumable", "food", "potion"]:
+		data["healing"] = item.healing
+		data["mana_restore"] = item.mana_restore
+		data["nutrition"] = item.nutrition
+		data["hydration"] = item.hydration
+
+	# Wand charges
+	if item.item_type == "wand":
+		data["charges"] = item.charges
+		data["max_charges"] = item.max_charges
+		data["spell_id"] = item.spell_id
+
+	# Modifiers
+	if item.modifiers and not item.modifiers.is_empty():
+		data["modifiers"] = item.modifiers.duplicate()
+
+	return data
+
+
+## Deserialize single item
+static func _deserialize_item(data: Dictionary) -> Item:
+	if data.is_empty() or not "id" in data:
+		return null
+
+	var item = ItemManager.create_item(data.id)
+	if item == null:
+		# Try creating generic item if ID not found
+		item = Item.new()
+		item.id = data.id
+
+	# Apply saved properties
+	item.display_name = data.get("display_name", item.display_name)
+	item.item_type = data.get("item_type", item.item_type)
+	item.stack_count = data.get("stack_count", 1)
+	item.identified = data.get("identified", true)
+	item.inscription = data.get("inscription", "")
+
+	# Equipment stats
+	if "damage" in data:
+		item.damage = data.damage
+	if "armor" in data:
+		item.armor = data.armor
+	if "stat_bonuses" in data:
+		item.stat_bonuses = data.stat_bonuses.duplicate()
+
+	# Consumable properties
+	if "healing" in data:
+		item.healing = data.healing
+	if "mana_restore" in data:
+		item.mana_restore = data.mana_restore
+	if "nutrition" in data:
+		item.nutrition = data.nutrition
+	if "hydration" in data:
+		item.hydration = data.hydration
+
+	# Wand
+	if "charges" in data:
+		item.charges = data.charges
+	if "max_charges" in data:
+		item.max_charges = data.max_charges
+	if "spell_id" in data:
+		item.spell_id = data.spell_id
+
+	# Modifiers
+	if "modifiers" in data:
+		item.modifiers = data.modifiers.duplicate()
+
+	return item
+
+
+## Serialize equipment dictionary
+static func _serialize_equipment(equipment: Dictionary) -> Dictionary:
+	var result: Dictionary = {}
+	for slot in equipment:
+		if equipment[slot]:
+			result[slot] = _serialize_item(equipment[slot])
+		else:
+			result[slot] = null
+	return result
+```
+
+---
+
+### Step 4: Create autoload/serializers/entity_serializer.gd
+
+```gdscript
+class_name EntitySerializer
+extends RefCounted
+
+## EntitySerializer - Handles entity (enemy/NPC) serialization
+
+
+## Serialize all entities
+static func serialize_all(entities: Array) -> Array:
+	var result: Array = []
+	for entity in entities:
+		if entity is Enemy:
+			result.append(serialize_enemy(entity))
+		elif "is_npc" in entity and entity.is_npc:
+			result.append(serialize_npc(entity))
+	return result
+
+
+## Deserialize all entities
+static func deserialize_all(data: Array) -> void:
+	for entity_data in data:
+		if entity_data.get("type") == "enemy":
+			deserialize_enemy(entity_data)
+		elif entity_data.get("type") == "npc":
+			deserialize_npc(entity_data)
+
+
+## Serialize single enemy
+static func serialize_enemy(enemy: Enemy) -> Dictionary:
+	return {
+		"type": "enemy",
+		"enemy_id": enemy.enemy_id,
+		"position": {"x": enemy.position.x, "y": enemy.position.y},
+		"hp": enemy.hp,
+		"max_hp": enemy.max_hp,
+		"is_aware": enemy.is_aware if "is_aware" in enemy else false,
+		"source_chunk": {"x": enemy.source_chunk.x, "y": enemy.source_chunk.y} if enemy.source_chunk else null,
+	}
+
+
+## Deserialize enemy
+static func deserialize_enemy(data: Dictionary) -> Enemy:
+	var pos = Vector2i(data.position.x, data.position.y)
+	var enemy = EntityManager.spawn_enemy(data.enemy_id, pos)
+	if enemy:
+		enemy.hp = data.get("hp", enemy.max_hp)
+		enemy.is_aware = data.get("is_aware", false)
+		if "source_chunk" in data and data.source_chunk:
+			enemy.source_chunk = Vector2i(data.source_chunk.x, data.source_chunk.y)
+	return enemy
+
+
+## Serialize NPC
+static func serialize_npc(npc) -> Dictionary:
+	return {
+		"type": "npc",
+		"npc_id": npc.npc_id if "npc_id" in npc else "",
+		"position": {"x": npc.position.x, "y": npc.position.y},
+		"shop_inventory": _serialize_shop_inventory(npc) if npc.has_method("get_shop_inventory") else [],
+	}
+
+
+## Deserialize NPC
+static func deserialize_npc(data: Dictionary) -> void:
+	var pos = Vector2i(data.position.x, data.position.y)
+	var npc = NPCManager.spawn_npc(data.npc_id, pos)
+	if npc and "shop_inventory" in data:
+		_deserialize_shop_inventory(npc, data.shop_inventory)
+
+
+## Serialize shop inventory
+static func _serialize_shop_inventory(npc) -> Array:
+	var result: Array = []
+	if npc.has_method("get_shop_inventory"):
+		for item in npc.get_shop_inventory():
+			result.append(InventorySerializer._serialize_item(item))
+	return result
+
+
+## Deserialize shop inventory
+static func _deserialize_shop_inventory(npc, data: Array) -> void:
+	if not npc.has_method("set_shop_inventory"):
+		return
+	var items: Array = []
+	for item_data in data:
+		var item = InventorySerializer._deserialize_item(item_data)
+		if item:
+			items.append(item)
+	npc.set_shop_inventory(items)
+```
+
+---
+
+### Step 5: Create autoload/serializers/map_serializer.gd
+
+```gdscript
+class_name MapSerializer
+extends RefCounted
+
+## MapSerializer - Handles map state serialization
+
+
+## Serialize map state
+static func serialize(map) -> Dictionary:
+	if map == null:
+		return {}
+
+	return {
+		"explored_tiles": _serialize_positions(map.explored_tiles if "explored_tiles" in map else []),
+		"ground_items": _serialize_ground_items(map),
+		"modified_tiles": _serialize_modified_tiles(map),
+		"features": _serialize_features(map),
+		"hazards": _serialize_hazards(),
+	}
+
+
+## Deserialize map state
+static func deserialize(map, data: Dictionary) -> void:
+	if map == null or data.is_empty():
+		return
+
+	# Explored tiles
+	if "explored_tiles" in data:
+		map.explored_tiles = _deserialize_positions(data.explored_tiles)
+
+	# Ground items
+	if "ground_items" in data:
+		_deserialize_ground_items(map, data.ground_items)
+
+	# Modified tiles
+	if "modified_tiles" in data:
+		_deserialize_modified_tiles(map, data.modified_tiles)
+
+	# Features
+	if "features" in data:
+		_deserialize_features(data.features)
+
+	# Hazards
+	if "hazards" in data:
+		_deserialize_hazards(data.hazards)
+
+
+## Serialize positions array
+static func _serialize_positions(positions) -> Array:
+	var result: Array = []
+	for pos in positions:
+		result.append({"x": pos.x, "y": pos.y})
+	return result
+
+
+## Deserialize positions array
+static func _deserialize_positions(data: Array) -> Array:
+	var result: Array = []
+	for pos_data in data:
+		result.append(Vector2i(pos_data.x, pos_data.y))
+	return result
+
+
+## Serialize ground items
+static func _serialize_ground_items(map) -> Array:
+	var result: Array = []
+	if not map.has_method("get_all_ground_items"):
+		return result
+
+	for entry in map.get_all_ground_items():
+		result.append({
+			"position": {"x": entry.position.x, "y": entry.position.y},
+			"item": InventorySerializer._serialize_item(entry.item),
+		})
+	return result
+
+
+## Deserialize ground items
+static func _deserialize_ground_items(map, data: Array) -> void:
+	for entry in data:
+		var pos = Vector2i(entry.position.x, entry.position.y)
+		var item = InventorySerializer._deserialize_item(entry.item)
+		if item and map.has_method("add_item_at"):
+			map.add_item_at(pos, item)
+
+
+## Serialize modified tiles (doors opened, walls broken, etc.)
+static func _serialize_modified_tiles(map) -> Array:
+	var result: Array = []
+	if not "modified_tiles" in map:
+		return result
+
+	for pos in map.modified_tiles:
+		var tile = map.modified_tiles[pos]
+		result.append({
+			"position": {"x": pos.x, "y": pos.y},
+			"tile_type": tile.tile_type if "tile_type" in tile else "",
+			"walkable": tile.walkable if "walkable" in tile else true,
+		})
+	return result
+
+
+## Deserialize modified tiles
+static func _deserialize_modified_tiles(map, data: Array) -> void:
+	if not "modified_tiles" in map:
+		return
+
+	for entry in data:
+		var pos = Vector2i(entry.position.x, entry.position.y)
+		map.modified_tiles[pos] = {
+			"tile_type": entry.get("tile_type", ""),
+			"walkable": entry.get("walkable", true),
+		}
+
+
+## Serialize placed features
+static func _serialize_features(map) -> Array:
+	var result: Array = []
+	for pos in FeatureManager.placed_features:
+		var feature = FeatureManager.placed_features[pos]
+		result.append({
+			"position": {"x": pos.x, "y": pos.y},
+			"feature_id": feature.feature_id if "feature_id" in feature else "",
+			"state": feature.state if "state" in feature else {},
+		})
+	return result
+
+
+## Deserialize features
+static func _deserialize_features(data: Array) -> void:
+	for entry in data:
+		var pos = Vector2i(entry.position.x, entry.position.y)
+		FeatureManager.place_feature(entry.feature_id, pos, entry.get("state", {}))
+
+
+## Serialize hazards
+static func _serialize_hazards() -> Array:
+	var result: Array = []
+	for pos in HazardManager.active_hazards:
+		var hazard = HazardManager.active_hazards[pos]
+		result.append({
+			"position": {"x": pos.x, "y": pos.y},
+			"hazard_id": hazard.hazard_id if "hazard_id" in hazard else "",
+			"detected": hazard.detected if "detected" in hazard else false,
+		})
+	return result
+
+
+## Deserialize hazards
+static func _deserialize_hazards(data: Array) -> void:
+	for entry in data:
+		var pos = Vector2i(entry.position.x, entry.position.y)
+		HazardManager.place_hazard(entry.hazard_id, pos, entry.get("detected", false))
+```
+
+---
+
+### Step 6: Update autoload/save_manager.gd
+
+1. **Add preloads**:
+```gdscript
+const PlayerSerializerClass = preload("res://autoload/serializers/player_serializer.gd")
+const InventorySerializerClass = preload("res://autoload/serializers/inventory_serializer.gd")
+const EntitySerializerClass = preload("res://autoload/serializers/entity_serializer.gd")
+const MapSerializerClass = preload("res://autoload/serializers/map_serializer.gd")
+```
+
+2. **Simplify save_game()**:
+```gdscript
+func save_game(slot: int) -> bool:
+	var save_data = {
+		"version": SAVE_VERSION,
+		"timestamp": Time.get_unix_time_from_system(),
+		"world_seed": GameManager.world_seed,
+		"player": PlayerSerializerClass.serialize(EntityManager.player),
+		"inventory": InventorySerializerClass.serialize(EntityManager.player.inventory),
+		"entities": EntitySerializerClass.serialize_all(EntityManager.entities),
+		"map": MapSerializerClass.serialize(MapManager.current_map),
+		"calendar": _serialize_calendar(),
+		"weather": _serialize_weather(),
+	}
+
+	return _write_save_file(slot, save_data)
+```
+
+3. **Simplify load_game()**:
+```gdscript
+func load_game(slot: int) -> bool:
+	var save_data = _read_save_file(slot)
+	if save_data.is_empty():
+		return false
+
+	# Restore world
+	GameManager.world_seed = save_data.get("world_seed", 0)
+
+	# Restore player
+	PlayerSerializerClass.deserialize(EntityManager.player, save_data.get("player", {}))
+	InventorySerializerClass.deserialize(EntityManager.player.inventory, save_data.get("inventory", {}))
+
+	# Restore entities
+	EntityManager.entities.clear()
+	EntitySerializerClass.deserialize_all(save_data.get("entities", []))
+
+	# Restore map
+	MapSerializerClass.deserialize(MapManager.current_map, save_data.get("map", {}))
+
+	# Restore time/weather
+	_deserialize_calendar(save_data.get("calendar", {}))
+	_deserialize_weather(save_data.get("weather", {}))
+
+	return true
+```
+
+4. **Remove old `_serialize_*` and `_deserialize_*` methods** that are now in serializers.
+
+---
+
+## Files Summary
+
+### New Files
+- `autoload/serializers/player_serializer.gd` (~200 lines)
+- `autoload/serializers/inventory_serializer.gd` (~150 lines)
+- `autoload/serializers/entity_serializer.gd` (~100 lines)
+- `autoload/serializers/map_serializer.gd` (~150 lines)
+
+### Modified Files
+- `autoload/save_manager.gd` - Reduced from 1,117 to ~400 lines
+
+---
+
+## Verification Checklist
+
+After completing all changes:
+
+- [ ] Game launches without errors
+- [ ] Start new game, play for a bit
+- [ ] Save game to slot 1
+- [ ] Load game from slot 1
+  - [ ] Player position correct
+  - [ ] Player stats correct (HP, MP, Stamina)
+  - [ ] Inventory items present
+  - [ ] Equipment slots correct
+  - [ ] Gold amount correct
+  - [ ] Level/experience correct
+- [ ] Save game to slot 2
+- [ ] Start new game
+- [ ] Load slot 1 - state restored
+- [ ] Load slot 2 - state restored
+- [ ] Autosave works correctly
+- [ ] Enemies restored at correct positions
+- [ ] Ground items restored
+- [ ] Map exploration state restored
+- [ ] Features (doors, chests) restored
+- [ ] Hazards restored
+- [ ] Time/date/weather restored
+- [ ] No new console warnings/errors
+
+---
+
+## Rollback
+
+If issues occur:
+```bash
+rm -rf autoload/serializers/
+git checkout HEAD -- autoload/save_manager.gd
+```
+
+Or revert entire commit:
+```bash
+git revert HEAD
+```

--- a/plans/features/v1.7/refactor-09-ascii-texture-mapper.md
+++ b/plans/features/v1.7/refactor-09-ascii-texture-mapper.md
@@ -1,0 +1,448 @@
+# Refactor 09: ASCII Texture Mapper
+
+**Risk Level**: Medium
+**Estimated Changes**: 1 new file, 1 file modified
+
+---
+
+## Goal
+
+Separate texture/character mapping logic from rendering in `ascii_renderer.gd` (1,182 lines).
+
+Extract character-to-tile-ID mapping, Unicode character handling, and tileset configuration into an `ASCIITextureMapper` class.
+
+---
+
+## Current State
+
+### rendering/ascii_renderer.gd
+The file mixes:
+- Character-to-tile ID mapping (~100 lines)
+- Unicode character map building (~50 lines)
+- Tileset creation and configuration
+- Actual rendering to TileMapLayers
+- Dirty flag management
+- FOV/visibility calculations
+- Chunk rendering
+
+### Code to Extract
+- `CHAR_TO_TILE` dictionary
+- `_build_unicode_map()`
+- `_get_tile_id_for_char()`
+- `_get_source_id()`
+- Character/symbol constants
+
+---
+
+## Implementation
+
+### Step 1: Create rendering/ascii_texture_mapper.gd
+
+```gdscript
+class_name ASCIITextureMapper
+extends RefCounted
+
+## ASCIITextureMapper - Handles ASCII character to tile ID mapping
+##
+## Extracted from ASCIIRenderer to separate mapping logic from rendering.
+## Provides character-to-tile-ID lookups for the renderer.
+
+
+# =============================================================================
+# CHARACTER TO TILE ID MAPPING
+# =============================================================================
+
+## Base ASCII characters (32-126) map directly to tile IDs 0-94
+## Extended characters use IDs 95+
+
+## Direct character to tile ID mapping for special/extended characters
+const EXTENDED_CHAR_MAP: Dictionary = {
+	# Box drawing
+	"─": 95,
+	"│": 96,
+	"┌": 97,
+	"┐": 98,
+	"└": 99,
+	"┘": 100,
+	"├": 101,
+	"┤": 102,
+	"┬": 103,
+	"┴": 104,
+	"┼": 105,
+	"═": 106,
+	"║": 107,
+	"╔": 108,
+	"╗": 109,
+	"╚": 110,
+	"╝": 111,
+
+	# Symbols
+	"●": 112,
+	"○": 113,
+	"◎": 114,
+	"◇": 115,
+	"◆": 116,
+	"□": 117,
+	"■": 118,
+	"▪": 119,
+	"▫": 120,
+	"▲": 121,
+	"▼": 122,
+	"►": 123,
+	"◄": 124,
+	"★": 125,
+	"☆": 126,
+
+	# Game-specific symbols
+	"♠": 127,
+	"♣": 128,
+	"♥": 129,
+	"♦": 130,
+	"†": 131,
+	"‡": 132,
+	"§": 133,
+	"¶": 134,
+	"©": 135,
+	"®": 136,
+	"™": 137,
+
+	# Terrain/feature symbols
+	"≈": 138,  # Water
+	"≡": 139,  # Deep water
+	"∿": 140,  # Waves
+	"⌂": 141,  # House
+	"⌐": 142,  # Floor corner
+	"¬": 143,  # Not symbol / wall
+	"░": 144,  # Light shade
+	"▒": 145,  # Medium shade
+	"▓": 146,  # Dark shade
+	"█": 147,  # Full block
+
+	# Entity symbols
+	"☺": 148,  # Player/friendly
+	"☻": 149,  # Enemy
+	"☼": 150,  # Sun/light
+	"♪": 151,  # Music/bard
+	"♫": 152,  # Notes
+	"☢": 153,  # Hazard
+	"☣": 154,  # Biohazard
+	"⚔": 155,  # Combat
+	"⚡": 156,  # Lightning
+	"⚠": 157,  # Warning
+
+	# Currency/items
+	"$": 36,   # Gold (standard ASCII)
+	"¢": 158,  # Cent
+	"£": 159,  # Pound
+	"¥": 160,  # Yen
+	"€": 161,  # Euro
+
+	# Arrows
+	"←": 162,
+	"→": 163,
+	"↑": 164,
+	"↓": 165,
+	"↔": 166,
+	"↕": 167,
+
+	# Misc
+	"∞": 168,
+	"≠": 169,
+	"≤": 170,
+	"≥": 171,
+	"±": 172,
+	"÷": 173,
+	"×": 174,
+	"√": 175,
+}
+
+## Reverse lookup: tile ID to character
+var _tile_to_char: Dictionary = {}
+
+## Unicode map for font texture generation
+var _unicode_map: Dictionary = {}
+
+
+func _init() -> void:
+	_build_reverse_map()
+	_build_unicode_map()
+
+
+## Build reverse lookup from tile ID to character
+func _build_reverse_map() -> void:
+	# Standard ASCII (32-126 -> tile IDs 0-94)
+	for code in range(32, 127):
+		var char_str = char(code)
+		var tile_id = code - 32
+		_tile_to_char[tile_id] = char_str
+
+	# Extended characters
+	for char_str in EXTENDED_CHAR_MAP:
+		var tile_id = EXTENDED_CHAR_MAP[char_str]
+		_tile_to_char[tile_id] = char_str
+
+
+## Build unicode map for all supported characters
+func _build_unicode_map() -> void:
+	# Standard ASCII
+	for code in range(32, 127):
+		_unicode_map[char(code)] = code - 32
+
+	# Extended characters
+	for char_str in EXTENDED_CHAR_MAP:
+		_unicode_map[char_str] = EXTENDED_CHAR_MAP[char_str]
+
+
+# =============================================================================
+# PUBLIC API
+# =============================================================================
+
+## Get tile ID for a character (0-based index into tileset)
+func get_tile_id(character: String) -> int:
+	if character.is_empty():
+		return 0  # Space
+
+	var first_char = character[0]
+
+	# Check extended map first
+	if first_char in EXTENDED_CHAR_MAP:
+		return EXTENDED_CHAR_MAP[first_char]
+
+	# Standard ASCII (32-126 -> 0-94)
+	var code = first_char.unicode_at(0)
+	if code >= 32 and code <= 126:
+		return code - 32
+
+	# Unknown character - return question mark
+	return 31  # '?' is ASCII 63, tile ID 31
+
+
+## Get character for a tile ID
+func get_character(tile_id: int) -> String:
+	if tile_id in _tile_to_char:
+		return _tile_to_char[tile_id]
+	return "?"
+
+
+## Check if a character is supported
+func is_supported(character: String) -> bool:
+	if character.is_empty():
+		return true  # Space is supported
+
+	var first_char = character[0]
+
+	if first_char in EXTENDED_CHAR_MAP:
+		return true
+
+	var code = first_char.unicode_at(0)
+	return code >= 32 and code <= 126
+
+
+## Get all characters that need to be in the tileset
+func get_all_characters() -> Array[String]:
+	var chars: Array[String] = []
+
+	# Standard ASCII
+	for code in range(32, 127):
+		chars.append(char(code))
+
+	# Extended
+	for char_str in EXTENDED_CHAR_MAP:
+		chars.append(char_str)
+
+	return chars
+
+
+## Get total number of tiles needed in tileset
+func get_tile_count() -> int:
+	# 95 standard ASCII + extended characters
+	var max_extended = 0
+	for char_str in EXTENDED_CHAR_MAP:
+		max_extended = maxi(max_extended, EXTENDED_CHAR_MAP[char_str])
+	return max_extended + 1
+
+
+## Get the unicode map for font texture generation
+func get_unicode_map() -> Dictionary:
+	return _unicode_map
+
+
+# =============================================================================
+# ENTITY/TILE SYMBOL HELPERS
+# =============================================================================
+
+## Standard symbols for common game elements
+const SYMBOL_PLAYER = "@"
+const SYMBOL_ENEMY = "E"
+const SYMBOL_NPC = "N"
+const SYMBOL_MERCHANT = "$"
+const SYMBOL_DOOR_CLOSED = "+"
+const SYMBOL_DOOR_OPEN = "'"
+const SYMBOL_STAIRS_DOWN = ">"
+const SYMBOL_STAIRS_UP = "<"
+const SYMBOL_CHEST_CLOSED = "="
+const SYMBOL_CHEST_OPEN = "_"
+const SYMBOL_WALL = "#"
+const SYMBOL_FLOOR = "."
+const SYMBOL_WATER = "≈"
+const SYMBOL_DEEP_WATER = "≡"
+const SYMBOL_GRASS = ","
+const SYMBOL_TREE = "♠"
+const SYMBOL_BUSH = "*"
+const SYMBOL_ROCK = "○"
+const SYMBOL_CAMPFIRE = "☼"
+const SYMBOL_TRAP = "^"
+const SYMBOL_ITEM = "!"
+const SYMBOL_GOLD = "$"
+const SYMBOL_CORPSE = "%"
+const SYMBOL_ALTAR = "_"
+const SYMBOL_STATUE = "&"
+
+
+## Get symbol for entity type
+static func get_entity_symbol(entity_type: String) -> String:
+	match entity_type:
+		"player":
+			return SYMBOL_PLAYER
+		"enemy":
+			return SYMBOL_ENEMY
+		"npc":
+			return SYMBOL_NPC
+		"merchant":
+			return SYMBOL_MERCHANT
+		_:
+			return "?"
+
+
+## Get symbol for tile type
+static func get_tile_symbol(tile_type: String) -> String:
+	match tile_type:
+		"wall":
+			return SYMBOL_WALL
+		"floor":
+			return SYMBOL_FLOOR
+		"water", "shallow_water":
+			return SYMBOL_WATER
+		"deep_water":
+			return SYMBOL_DEEP_WATER
+		"grass":
+			return SYMBOL_GRASS
+		"tree":
+			return SYMBOL_TREE
+		"door_closed":
+			return SYMBOL_DOOR_CLOSED
+		"door_open":
+			return SYMBOL_DOOR_OPEN
+		"stairs_down":
+			return SYMBOL_STAIRS_DOWN
+		"stairs_up":
+			return SYMBOL_STAIRS_UP
+		_:
+			return SYMBOL_FLOOR
+```
+
+---
+
+### Step 2: Update rendering/ascii_renderer.gd
+
+1. **Add preload and instance**:
+```gdscript
+const ASCIITextureMapperClass = preload("res://rendering/ascii_texture_mapper.gd")
+
+var _texture_mapper: ASCIITextureMapper = null
+```
+
+2. **Initialize in `_init()` or `_ready()`**:
+```gdscript
+func _init() -> void:
+	_texture_mapper = ASCIITextureMapperClass.new()
+```
+
+3. **Replace direct character mapping**:
+```gdscript
+# Before:
+func _get_tile_id_for_char(character: String) -> int:
+	if character in CHAR_TO_TILE:
+		return CHAR_TO_TILE[character]
+	var code = character.unicode_at(0)
+	if code >= 32 and code <= 126:
+		return code - 32
+	return 31
+
+# After:
+func _get_tile_id_for_char(character: String) -> int:
+	return _texture_mapper.get_tile_id(character)
+```
+
+4. **Remove** the following from ascii_renderer.gd:
+- `CHAR_TO_TILE` dictionary constant
+- `_build_unicode_map()` method
+- `_unicode_map` variable
+- Any inline character mapping code
+
+5. **Update font texture generation** to use mapper:
+```gdscript
+func _generate_tileset_texture() -> ImageTexture:
+	var chars = _texture_mapper.get_all_characters()
+	var tile_count = _texture_mapper.get_tile_count()
+	# ... rest of texture generation using chars and tile_count
+```
+
+---
+
+## Files Summary
+
+### New Files
+- `rendering/ascii_texture_mapper.gd` (~250 lines)
+
+### Modified Files
+- `rendering/ascii_renderer.gd` - Reduced by ~150 lines
+
+---
+
+## Verification Checklist
+
+After completing all changes:
+
+- [ ] Game launches without errors
+- [ ] Start new game
+- [ ] All terrain renders correctly
+  - [ ] Walls (#)
+  - [ ] Floors (.)
+  - [ ] Water (≈)
+  - [ ] Trees (♠)
+  - [ ] Grass (,)
+- [ ] All entities render correctly
+  - [ ] Player (@)
+  - [ ] Enemies (various letters)
+  - [ ] NPCs (N)
+  - [ ] Merchants ($)
+- [ ] All features render correctly
+  - [ ] Doors (+ and ')
+  - [ ] Stairs (> and <)
+  - [ ] Chests (= and _)
+- [ ] All items render correctly
+  - [ ] Ground items (!)
+  - [ ] Gold piles ($)
+- [ ] Special characters display correctly
+  - [ ] Box drawing characters
+  - [ ] Symbols (●, ○, ♠, etc.)
+- [ ] FOV and explored areas render correctly
+- [ ] Chunk transitions render correctly
+- [ ] No visual glitches or missing characters
+- [ ] No new console warnings/errors
+
+---
+
+## Rollback
+
+If issues occur:
+```bash
+git checkout HEAD -- rendering/ascii_renderer.gd
+rm rendering/ascii_texture_mapper.gd
+```
+
+Or revert entire commit:
+```bash
+git revert HEAD
+```

--- a/plans/features/v1.7/refactor-10-player-components.md
+++ b/plans/features/v1.7/refactor-10-player-components.md
@@ -1,0 +1,986 @@
+# Refactor 10: Player Components
+
+**Risk Level**: Medium-High
+**Estimated Changes**: 4 new files, 1 file significantly reduced
+
+---
+
+## Goal
+
+Decompose the `player.gd` god object (1,970 lines) into focused components using composition:
+- SummonComponent - Handles summoned creature management
+- RaceComponent - Handles racial traits and abilities
+- ClassComponent - Handles class feats and progression
+- ConcentrationComponent - Handles concentration spell mechanics
+
+---
+
+## Current State
+
+### entities/player.gd (1,970 lines)
+The Player class handles too many responsibilities:
+- Core entity state (position, HP, attributes) - Keep in Player
+- Summon management (~200 lines) - Extract
+- Concentration mechanics (~150 lines) - Extract
+- Racial traits and abilities (~100 lines) - Extract
+- Class feats and mechanics (~100 lines) - Extract
+- Inventory/equipment - Delegates to Inventory class
+- Combat - Delegates to CombatSystem
+- Survival - Delegates to SurvivalSystem
+
+---
+
+## Implementation
+
+### Step 1: Create entities/components/ Directory
+
+```bash
+mkdir -p entities/components
+```
+
+---
+
+### Step 2: Create entities/components/summon_component.gd
+
+```gdscript
+class_name SummonComponent
+extends RefCounted
+
+## SummonComponent - Manages summoned creatures for player
+##
+## Handles adding, removing, commanding, and updating summons.
+
+signal summon_added(summon: Entity)
+signal summon_removed(summon: Entity)
+signal summons_cleared()
+
+# Maximum number of active summons
+const MAX_SUMMONS: int = 3
+
+# Active summons
+var summons: Array[Entity] = []
+
+# Owner reference
+var _owner: Entity = null
+
+
+func _init(owner: Entity = null) -> void:
+	_owner = owner
+
+
+func set_owner(owner: Entity) -> void:
+	_owner = owner
+
+
+## Add a summon to the player's control
+func add_summon(summon: Entity) -> bool:
+	if summon == null:
+		return false
+
+	if summons.size() >= MAX_SUMMONS:
+		EventBus.message_logged.emit("You cannot control any more summons.")
+		return false
+
+	if summon in summons:
+		return false
+
+	summons.append(summon)
+	summon.is_summoned = true
+	summon.summoner = _owner
+
+	# Mark as friendly
+	if "faction" in summon:
+		summon.faction = "player"
+
+	summon_added.emit(summon)
+	EventBus.message_logged.emit("You gain control of %s." % summon.display_name)
+	return true
+
+
+## Remove a summon from control
+func remove_summon(summon: Entity) -> void:
+	if summon == null or summon not in summons:
+		return
+
+	summons.erase(summon)
+	summon.is_summoned = false
+	summon.summoner = null
+
+	summon_removed.emit(summon)
+
+
+## Dismiss a summon (remove and despawn)
+func dismiss_summon(summon: Entity) -> void:
+	if summon == null or summon not in summons:
+		return
+
+	remove_summon(summon)
+
+	# Remove from game
+	EntityManager.remove_entity(summon)
+	EventBus.message_logged.emit("%s fades away." % summon.display_name)
+
+
+## Dismiss all summons
+func dismiss_all_summons() -> void:
+	var summons_to_dismiss = summons.duplicate()
+	for summon in summons_to_dismiss:
+		dismiss_summon(summon)
+	summons_cleared.emit()
+
+
+## Get all active summons
+func get_summons() -> Array[Entity]:
+	return summons
+
+
+## Get summon count
+func get_summon_count() -> int:
+	return summons.size()
+
+
+## Check if at summon capacity
+func is_at_capacity() -> bool:
+	return summons.size() >= MAX_SUMMONS
+
+
+## Check if entity is a summon of this player
+func is_my_summon(entity: Entity) -> bool:
+	return entity in summons
+
+
+## Process summon turns (called during turn processing)
+func process_summon_turns() -> void:
+	for summon in summons:
+		if summon.hp <= 0:
+			# Summon died
+			remove_summon(summon)
+			continue
+
+		# Summons follow player by default
+		if summon.has_method("take_turn"):
+			_command_summon_follow(summon)
+			summon.take_turn()
+
+
+## Command summon to follow player
+func _command_summon_follow(summon: Entity) -> void:
+	if _owner == null:
+		return
+
+	# Set target to move near player
+	var target_pos = _find_position_near_owner()
+	if summon.has_method("set_move_target"):
+		summon.set_move_target(target_pos)
+
+
+## Find empty position near owner
+func _find_position_near_owner() -> Vector2i:
+	if _owner == null:
+		return Vector2i.ZERO
+
+	var map = MapManager.current_map
+	if map == null:
+		return _owner.position
+
+	# Check adjacent positions
+	var directions = [
+		Vector2i(1, 0), Vector2i(-1, 0),
+		Vector2i(0, 1), Vector2i(0, -1),
+		Vector2i(1, 1), Vector2i(-1, -1),
+		Vector2i(1, -1), Vector2i(-1, 1),
+	]
+
+	for dir in directions:
+		var pos = _owner.position + dir
+		if map.is_walkable(pos) and not EntityManager.get_entity_at(pos):
+			return pos
+
+	return _owner.position
+
+
+## Handle summon death
+func on_summon_died(summon: Entity) -> void:
+	if summon in summons:
+		remove_summon(summon)
+		EventBus.message_logged.emit("%s has been destroyed." % summon.display_name)
+
+
+## Serialize summon state
+func serialize() -> Array:
+	var result: Array = []
+	for summon in summons:
+		result.append({
+			"enemy_id": summon.enemy_id if "enemy_id" in summon else "",
+			"position": {"x": summon.position.x, "y": summon.position.y},
+			"hp": summon.hp,
+			"max_hp": summon.max_hp,
+		})
+	return result
+
+
+## Deserialize summon state
+func deserialize(data: Array) -> void:
+	dismiss_all_summons()
+
+	for summon_data in data:
+		if summon_data.enemy_id.is_empty():
+			continue
+
+		var pos = Vector2i(summon_data.position.x, summon_data.position.y)
+		var summon = EntityManager.spawn_enemy(summon_data.enemy_id, pos)
+		if summon:
+			summon.hp = summon_data.get("hp", summon.max_hp)
+			add_summon(summon)
+```
+
+---
+
+### Step 3: Create entities/components/concentration_component.gd
+
+```gdscript
+class_name ConcentrationComponent
+extends RefCounted
+
+## ConcentrationComponent - Manages concentration spell mechanics
+##
+## Tracks active concentration spells and handles interruption.
+
+signal concentration_started(spell)
+signal concentration_ended(spell)
+signal concentration_broken(spell, reason: String)
+
+# Currently concentrating spell
+var active_spell = null
+var spell_target: Vector2i = Vector2i.ZERO
+var duration_remaining: int = 0
+
+# Owner reference
+var _owner: Entity = null
+
+
+func _init(owner: Entity = null) -> void:
+	_owner = owner
+
+
+func set_owner(owner: Entity) -> void:
+	_owner = owner
+
+
+## Start concentrating on a spell
+func start_concentration(spell, target: Vector2i, duration: int) -> bool:
+	if spell == null:
+		return false
+
+	# Break existing concentration
+	if active_spell != null:
+		break_concentration("Started new concentration spell")
+
+	active_spell = spell
+	spell_target = target
+	duration_remaining = duration
+
+	concentration_started.emit(spell)
+	EventBus.message_logged.emit("You begin concentrating on %s." % spell.name)
+	return true
+
+
+## End concentration normally (spell completed or dismissed)
+func end_concentration() -> void:
+	if active_spell == null:
+		return
+
+	var spell = active_spell
+	active_spell = null
+	spell_target = Vector2i.ZERO
+	duration_remaining = 0
+
+	concentration_ended.emit(spell)
+	EventBus.message_logged.emit("You stop concentrating on %s." % spell.name)
+
+
+## Break concentration (interrupted by damage, movement, etc.)
+func break_concentration(reason: String = "Interrupted") -> void:
+	if active_spell == null:
+		return
+
+	var spell = active_spell
+	active_spell = null
+	spell_target = Vector2i.ZERO
+	duration_remaining = 0
+
+	concentration_broken.emit(spell, reason)
+	EventBus.message_logged.emit("Your concentration on %s is broken! (%s)" % [spell.name, reason])
+
+	# Handle spell end effects
+	_on_spell_broken(spell)
+
+
+## Check if currently concentrating
+func is_concentrating() -> bool:
+	return active_spell != null
+
+
+## Get current concentration spell
+func get_active_spell():
+	return active_spell
+
+
+## Get concentration target position
+func get_target() -> Vector2i:
+	return spell_target
+
+
+## Process turn (reduce duration, maintain effects)
+func process_turn() -> void:
+	if active_spell == null:
+		return
+
+	duration_remaining -= 1
+
+	if duration_remaining <= 0:
+		EventBus.message_logged.emit("%s spell duration expired." % active_spell.name)
+		end_concentration()
+		return
+
+	# Maintain spell effects
+	_maintain_spell_effects()
+
+
+## Called when damage is taken - may break concentration
+func on_damage_taken(damage: int) -> bool:
+	if active_spell == null:
+		return false
+
+	# Concentration check: CON save vs 10 or half damage (whichever higher)
+	var dc = maxi(10, damage / 2)
+	var con_mod = 0
+	if _owner and "attributes" in _owner:
+		con_mod = (_owner.attributes.get("CON", 10) - 10) / 2
+
+	var roll = randi() % 20 + 1 + con_mod
+
+	if roll < dc:
+		break_concentration("Took %d damage (failed CON save %d vs DC %d)" % [damage, roll, dc])
+		return true
+
+	return false
+
+
+## Maintain ongoing spell effects
+func _maintain_spell_effects() -> void:
+	if active_spell == null or _owner == null:
+		return
+
+	# Different spells have different maintenance effects
+	# This would be expanded based on spell definitions
+	pass
+
+
+## Handle spell being broken
+func _on_spell_broken(spell) -> void:
+	# Clean up any ongoing effects
+	# E.g., dismiss summoned creatures, end buffs, etc.
+
+	if spell.has("summon_on_break"):
+		# Remove summoned creatures when concentration breaks
+		if _owner and _owner.has_method("dismiss_all_summons"):
+			_owner.dismiss_all_summons()
+
+
+## Serialize concentration state
+func serialize() -> Dictionary:
+	if active_spell == null:
+		return {}
+
+	return {
+		"spell_id": active_spell.id if "id" in active_spell else "",
+		"target": {"x": spell_target.x, "y": spell_target.y},
+		"duration": duration_remaining,
+	}
+
+
+## Deserialize concentration state (just stores data, actual restoration happens later)
+func deserialize(data: Dictionary) -> void:
+	# Concentration is complex to restore - store pending data
+	if data.is_empty():
+		return
+
+	# This would need to re-cast the spell on load
+	# For now, just note that concentration was active
+	if "spell_id" in data and not data.spell_id.is_empty():
+		EventBus.message_logged.emit("(Concentration spell was active before save)")
+```
+
+---
+
+### Step 4: Create entities/components/race_component.gd
+
+```gdscript
+class_name RaceComponent
+extends RefCounted
+
+## RaceComponent - Manages racial traits and abilities
+##
+## Handles racial bonuses, abilities, and special mechanics.
+
+signal ability_used(ability_id: String)
+signal ability_cooldown_ended(ability_id: String)
+
+# Race ID
+var race_id: String = ""
+
+# Racial abilities (list of ability IDs)
+var abilities: Array[String] = []
+
+# Ability cooldowns (ability_id -> turns remaining)
+var cooldowns: Dictionary = {}
+
+# Owner reference
+var _owner: Entity = null
+
+
+func _init(owner: Entity = null) -> void:
+	_owner = owner
+
+
+func set_owner(owner: Entity) -> void:
+	_owner = owner
+
+
+## Set race and apply initial bonuses
+func set_race(id: String) -> void:
+	race_id = id
+
+	var race_data = RaceManager.get_race(id)
+	if race_data == null:
+		push_warning("RaceComponent: Unknown race ID: %s" % id)
+		return
+
+	# Get racial abilities
+	abilities = race_data.get("abilities", []).duplicate()
+
+	# Apply attribute bonuses
+	if _owner and "attributes" in _owner:
+		var bonuses = race_data.get("attribute_bonuses", {})
+		for attr in bonuses:
+			if attr in _owner.attributes:
+				_owner.attributes[attr] += bonuses[attr]
+
+
+## Get list of racial abilities
+func get_abilities() -> Array[String]:
+	return abilities
+
+
+## Check if has a specific ability
+func has_ability(ability_id: String) -> bool:
+	return ability_id in abilities
+
+
+## Use a racial ability
+func use_ability(ability_id: String) -> Dictionary:
+	if not has_ability(ability_id):
+		return {"success": false, "message": "You don't have that ability"}
+
+	if is_on_cooldown(ability_id):
+		var remaining = cooldowns.get(ability_id, 0)
+		return {"success": false, "message": "Ability on cooldown (%d turns)" % remaining}
+
+	var ability_data = RaceManager.get_ability(ability_id)
+	if ability_data == null:
+		return {"success": false, "message": "Unknown ability"}
+
+	# Execute ability
+	var result = _execute_ability(ability_id, ability_data)
+
+	if result.success:
+		# Set cooldown
+		var cooldown = ability_data.get("cooldown", 0)
+		if cooldown > 0:
+			cooldowns[ability_id] = cooldown
+
+		ability_used.emit(ability_id)
+
+	return result
+
+
+## Check if ability is on cooldown
+func is_on_cooldown(ability_id: String) -> bool:
+	return cooldowns.get(ability_id, 0) > 0
+
+
+## Get remaining cooldown for ability
+func get_cooldown(ability_id: String) -> int:
+	return cooldowns.get(ability_id, 0)
+
+
+## Process turn (reduce cooldowns)
+func process_turn() -> void:
+	var expired: Array[String] = []
+
+	for ability_id in cooldowns:
+		cooldowns[ability_id] -= 1
+		if cooldowns[ability_id] <= 0:
+			expired.append(ability_id)
+
+	for ability_id in expired:
+		cooldowns.erase(ability_id)
+		ability_cooldown_ended.emit(ability_id)
+
+
+## Execute a racial ability
+func _execute_ability(ability_id: String, data: Dictionary) -> Dictionary:
+	var ability_type = data.get("type", "")
+
+	match ability_type:
+		"heal":
+			return _execute_heal_ability(data)
+		"buff":
+			return _execute_buff_ability(data)
+		"damage":
+			return _execute_damage_ability(data)
+		"utility":
+			return _execute_utility_ability(ability_id, data)
+		_:
+			return {"success": false, "message": "Unknown ability type"}
+
+
+func _execute_heal_ability(data: Dictionary) -> Dictionary:
+	if _owner == null:
+		return {"success": false, "message": "No owner"}
+
+	var amount = data.get("amount", 10)
+	var healed = mini(amount, _owner.max_hp - _owner.hp)
+	_owner.hp += healed
+
+	EventBus.player_health_changed.emit(_owner.hp, _owner.max_hp)
+	return {"success": true, "message": "Healed %d HP" % healed}
+
+
+func _execute_buff_ability(data: Dictionary) -> Dictionary:
+	if _owner == null or not _owner.has_method("add_buff"):
+		return {"success": false, "message": "Cannot apply buff"}
+
+	var buff_id = data.get("buff_id", "")
+	var duration = data.get("duration", 10)
+	_owner.add_buff(buff_id, {"duration": duration})
+
+	return {"success": true, "message": "Activated %s" % data.get("name", "ability")}
+
+
+func _execute_damage_ability(data: Dictionary) -> Dictionary:
+	# Would need target selection
+	return {"success": false, "message": "Damage abilities need targeting"}
+
+
+func _execute_utility_ability(ability_id: String, data: Dictionary) -> Dictionary:
+	# Handle specific utility abilities
+	match ability_id:
+		"darkvision":
+			# Toggle darkvision
+			return {"success": true, "message": "Your eyes adjust to the darkness"}
+		"detect_traps":
+			# Reveal nearby traps
+			return _detect_nearby_traps()
+		_:
+			return {"success": true, "message": "Used %s" % data.get("name", ability_id)}
+
+
+func _detect_nearby_traps() -> Dictionary:
+	if _owner == null:
+		return {"success": false, "message": "No owner"}
+
+	var detected = HazardManager.reveal_hazards_near(_owner.position, 5)
+	if detected > 0:
+		return {"success": true, "message": "Detected %d hidden traps!" % detected}
+	return {"success": true, "message": "No traps detected nearby"}
+
+
+## Serialize race state
+func serialize() -> Dictionary:
+	return {
+		"race_id": race_id,
+		"abilities": abilities.duplicate(),
+		"cooldowns": cooldowns.duplicate(),
+	}
+
+
+## Deserialize race state
+func deserialize(data: Dictionary) -> void:
+	race_id = data.get("race_id", "")
+	abilities = data.get("abilities", []).duplicate()
+	cooldowns = data.get("cooldowns", {}).duplicate()
+```
+
+---
+
+### Step 5: Create entities/components/class_component.gd
+
+```gdscript
+class_name ClassComponent
+extends RefCounted
+
+## ClassComponent - Manages class feats and progression
+##
+## Handles class-specific abilities, feat unlocking, and specialization.
+
+signal feat_unlocked(feat_id: String)
+signal feat_used(feat_id: String)
+
+# Class ID
+var class_id: String = ""
+
+# Unlocked feats
+var feats: Array[String] = []
+
+# Feat cooldowns
+var cooldowns: Dictionary = {}
+
+# Specialization (if applicable)
+var specialization: String = ""
+
+# Owner reference
+var _owner: Entity = null
+
+
+func _init(owner: Entity = null) -> void:
+	_owner = owner
+
+
+func set_owner(owner: Entity) -> void:
+	_owner = owner
+
+
+## Set class and apply initial feats
+func set_class(id: String) -> void:
+	class_id = id
+
+	var class_data = ClassManager.get_class(id)
+	if class_data == null:
+		push_warning("ClassComponent: Unknown class ID: %s" % id)
+		return
+
+	# Get starting feats
+	feats = class_data.get("starting_feats", []).duplicate()
+
+
+## Get list of unlocked feats
+func get_feats() -> Array[String]:
+	return feats
+
+
+## Check if has a specific feat
+func has_feat(feat_id: String) -> bool:
+	return feat_id in feats
+
+
+## Unlock a new feat (from leveling)
+func unlock_feat(feat_id: String) -> bool:
+	if feat_id in feats:
+		return false  # Already have it
+
+	var feat_data = ClassManager.get_feat(feat_id)
+	if feat_data == null:
+		return false
+
+	# Check prerequisites
+	if not _meets_feat_prerequisites(feat_data):
+		return false
+
+	feats.append(feat_id)
+	feat_unlocked.emit(feat_id)
+	EventBus.message_logged.emit("Unlocked feat: %s" % feat_data.get("name", feat_id))
+	return true
+
+
+## Use a class feat
+func use_feat(feat_id: String) -> Dictionary:
+	if not has_feat(feat_id):
+		return {"success": false, "message": "You don't have that feat"}
+
+	if is_on_cooldown(feat_id):
+		var remaining = cooldowns.get(feat_id, 0)
+		return {"success": false, "message": "Feat on cooldown (%d turns)" % remaining}
+
+	var feat_data = ClassManager.get_feat(feat_id)
+	if feat_data == null:
+		return {"success": false, "message": "Unknown feat"}
+
+	# Check resource cost
+	var cost = feat_data.get("stamina_cost", 0)
+	if cost > 0 and _owner and _owner.stamina < cost:
+		return {"success": false, "message": "Not enough stamina (%d required)" % cost}
+
+	# Execute feat
+	var result = _execute_feat(feat_id, feat_data)
+
+	if result.success:
+		# Pay cost
+		if cost > 0 and _owner:
+			_owner.stamina -= cost
+			EventBus.player_stamina_changed.emit(_owner.stamina, _owner.max_stamina)
+
+		# Set cooldown
+		var cooldown = feat_data.get("cooldown", 0)
+		if cooldown > 0:
+			cooldowns[feat_id] = cooldown
+
+		feat_used.emit(feat_id)
+
+	return result
+
+
+## Check if feat is on cooldown
+func is_on_cooldown(feat_id: String) -> bool:
+	return cooldowns.get(feat_id, 0) > 0
+
+
+## Process turn (reduce cooldowns)
+func process_turn() -> void:
+	var expired: Array[String] = []
+
+	for feat_id in cooldowns:
+		cooldowns[feat_id] -= 1
+		if cooldowns[feat_id] <= 0:
+			expired.append(feat_id)
+
+	for feat_id in expired:
+		cooldowns.erase(feat_id)
+
+
+## Get feats available at a given level
+func get_feats_for_level(level: int) -> Array[String]:
+	var class_data = ClassManager.get_class(class_id)
+	if class_data == null:
+		return []
+
+	var available: Array[String] = []
+	var feat_progression = class_data.get("feat_progression", {})
+
+	for lvl in feat_progression:
+		if int(lvl) <= level:
+			for feat_id in feat_progression[lvl]:
+				if feat_id not in feats:
+					available.append(feat_id)
+
+	return available
+
+
+## Check if prerequisites are met for a feat
+func _meets_feat_prerequisites(feat_data: Dictionary) -> bool:
+	var prereqs = feat_data.get("prerequisites", {})
+
+	# Level requirement
+	if "level" in prereqs:
+		if _owner == null or _owner.level < prereqs.level:
+			return false
+
+	# Required feats
+	if "feats" in prereqs:
+		for required_feat in prereqs.feats:
+			if required_feat not in feats:
+				return false
+
+	# Stat requirements
+	if "attributes" in prereqs and _owner:
+		for attr in prereqs.attributes:
+			if _owner.attributes.get(attr, 0) < prereqs.attributes[attr]:
+				return false
+
+	return true
+
+
+## Execute a class feat
+func _execute_feat(feat_id: String, data: Dictionary) -> Dictionary:
+	var feat_type = data.get("type", "")
+
+	match feat_type:
+		"attack":
+			return _execute_attack_feat(data)
+		"buff":
+			return _execute_buff_feat(data)
+		"passive":
+			return {"success": true, "message": "Passive feat active"}
+		_:
+			return {"success": true, "message": "Used %s" % data.get("name", feat_id)}
+
+
+func _execute_attack_feat(data: Dictionary) -> Dictionary:
+	# Would need target selection and combat integration
+	var damage_bonus = data.get("damage_bonus", 0)
+	return {"success": true, "message": "Next attack deals +%d damage" % damage_bonus, "damage_bonus": damage_bonus}
+
+
+func _execute_buff_feat(data: Dictionary) -> Dictionary:
+	if _owner == null or not _owner.has_method("add_buff"):
+		return {"success": false, "message": "Cannot apply buff"}
+
+	var buff_id = data.get("buff_id", "")
+	var duration = data.get("duration", 5)
+	_owner.add_buff(buff_id, {"duration": duration})
+
+	return {"success": true, "message": "Activated %s" % data.get("name", "feat")}
+
+
+## Serialize class state
+func serialize() -> Dictionary:
+	return {
+		"class_id": class_id,
+		"feats": feats.duplicate(),
+		"cooldowns": cooldowns.duplicate(),
+		"specialization": specialization,
+	}
+
+
+## Deserialize class state
+func deserialize(data: Dictionary) -> void:
+	class_id = data.get("class_id", "")
+	feats = data.get("feats", []).duplicate()
+	cooldowns = data.get("cooldowns", {}).duplicate()
+	specialization = data.get("specialization", "")
+```
+
+---
+
+### Step 6: Update entities/player.gd
+
+1. **Add preloads and component instances**:
+```gdscript
+const SummonComponentClass = preload("res://entities/components/summon_component.gd")
+const ConcentrationComponentClass = preload("res://entities/components/concentration_component.gd")
+const RaceComponentClass = preload("res://entities/components/race_component.gd")
+const ClassComponentClass = preload("res://entities/components/class_component.gd")
+
+# Components
+var summon_component: SummonComponent = null
+var concentration_component: ConcentrationComponent = null
+var race_component: RaceComponent = null
+var class_component: ClassComponent = null
+```
+
+2. **Initialize components in `_init()`**:
+```gdscript
+func _init() -> void:
+	summon_component = SummonComponentClass.new(self)
+	concentration_component = ConcentrationComponentClass.new(self)
+	race_component = RaceComponentClass.new(self)
+	class_component = ClassComponentClass.new(self)
+```
+
+3. **Delegate methods to components**:
+```gdscript
+# Summons
+func add_summon(summon: Entity) -> bool:
+	return summon_component.add_summon(summon)
+
+func dismiss_summon(summon: Entity) -> void:
+	summon_component.dismiss_summon(summon)
+
+func get_summons() -> Array[Entity]:
+	return summon_component.get_summons()
+
+# Concentration
+func start_concentration(spell, target: Vector2i, duration: int) -> bool:
+	return concentration_component.start_concentration(spell, target, duration)
+
+func is_concentrating() -> bool:
+	return concentration_component.is_concentrating()
+
+# Race
+func set_race(id: String) -> void:
+	race_component.set_race(id)
+	race_id = id
+
+func use_racial_ability(ability_id: String) -> Dictionary:
+	return race_component.use_ability(ability_id)
+
+# Class
+func set_class(id: String) -> void:
+	class_component.set_class(id)
+	class_id = id
+
+func use_class_feat(feat_id: String) -> Dictionary:
+	return class_component.use_feat(feat_id)
+```
+
+4. **Update `process_turn()`** to use components:
+```gdscript
+func process_turn() -> void:
+	# ... existing code ...
+
+	# Process component turns
+	race_component.process_turn()
+	class_component.process_turn()
+	concentration_component.process_turn()
+	summon_component.process_summon_turns()
+```
+
+5. **Remove old implementation code** for:
+- Summon management methods
+- Concentration methods
+- Racial ability methods
+- Class feat methods
+
+---
+
+## Files Summary
+
+### New Files
+- `entities/components/summon_component.gd` (~200 lines)
+- `entities/components/concentration_component.gd` (~180 lines)
+- `entities/components/race_component.gd` (~200 lines)
+- `entities/components/class_component.gd` (~220 lines)
+
+### Modified Files
+- `entities/player.gd` - Reduced from 1,970 to ~800 lines
+
+---
+
+## Verification Checklist
+
+After completing all changes:
+
+- [ ] Game launches without errors
+- [ ] Create new character
+  - [ ] Select race - bonuses apply
+  - [ ] Select class - starting feats granted
+- [ ] Racial abilities
+  - [ ] View racial abilities in character sheet
+  - [ ] Use racial ability
+  - [ ] Cooldown applies and counts down
+- [ ] Class feats
+  - [ ] View class feats in character sheet
+  - [ ] Use class feat
+  - [ ] Cooldown applies
+  - [ ] Level up unlocks new feats
+- [ ] Summons (if implemented)
+  - [ ] Cast summoning spell
+  - [ ] Summon follows player
+  - [ ] Summon attacks enemies
+  - [ ] Dismiss summon
+- [ ] Concentration
+  - [ ] Cast concentration spell
+  - [ ] Effect maintained
+  - [ ] Taking damage may break concentration
+  - [ ] Manual end concentration
+- [ ] Save and load
+  - [ ] All component state preserved
+  - [ ] Cooldowns persist
+  - [ ] Summons restored (if saved)
+- [ ] No new console warnings/errors
+
+---
+
+## Rollback
+
+If issues occur:
+```bash
+rm -rf entities/components/
+git checkout HEAD -- entities/player.gd
+```
+
+Or revert entire commit:
+```bash
+git revert HEAD
+```

--- a/plans/features/v1.7/refactor-11-game-ui-coordinator.md
+++ b/plans/features/v1.7/refactor-11-game-ui-coordinator.md
@@ -1,0 +1,526 @@
+# Refactor 11: Game UI Coordinator
+
+**Risk Level**: High
+**Estimated Changes**: 1 new file, 1 file partially reduced
+
+---
+
+## Goal
+
+Extract UI coordination from `game.gd` (3,337 lines) into a dedicated `UICoordinator` class.
+
+This is the first of three plans to decompose game.gd. Focus on:
+- All `_setup_*_screen()` methods (20+ methods)
+- All `_on_*_closed()` callbacks
+- Screen lifecycle management
+- UI state tracking
+
+---
+
+## Current State
+
+### scenes/game.gd UI-Related Code
+
+**Setup Methods (~400 lines):**
+- `_setup_inventory_screen()`
+- `_setup_character_sheet()`
+- `_setup_crafting_screen()`
+- `_setup_help_screen()`
+- `_setup_shop_screen()`
+- `_setup_container_screen()`
+- `_setup_level_up_screen()`
+- `_setup_spell_list_screen()`
+- `_setup_ritual_screen()`
+- `_setup_special_actions_screen()`
+- `_setup_world_map_screen()`
+- `_setup_debug_command_menu()`
+- And more...
+
+**Close Handlers (~200 lines):**
+- `_on_inventory_closed()`
+- `_on_character_sheet_closed()`
+- `_on_crafting_closed()`
+- And corresponding handlers for each screen...
+
+**State Tracking:**
+- `current_open_screen`
+- Various `*_screen` node references
+
+---
+
+## Implementation
+
+### Step 1: Create systems/ui_coordinator.gd
+
+```gdscript
+class_name UICoordinator
+extends RefCounted
+
+## UICoordinator - Manages UI screen lifecycle
+##
+## Handles opening, closing, and state management for all game UI screens.
+## Extracted from game.gd to reduce file size and improve organization.
+
+signal screen_opened(screen_name: String)
+signal screen_closed(screen_name: String)
+
+# Screen references (set by game.gd)
+var screens: Dictionary = {}
+
+# Currently open screen (if any)
+var current_screen: String = ""
+
+# Player reference
+var player: Player = null
+
+# Input handler reference (for blocking input during UI)
+var input_handler = null
+
+
+func _init() -> void:
+	pass
+
+
+## Register a screen with the coordinator
+func register_screen(name: String, node: Control) -> void:
+	screens[name] = node
+	node.hide()
+
+	# Connect closed signal if available
+	if node.has_signal("closed"):
+		node.closed.connect(_on_screen_closed.bind(name))
+
+
+## Set player reference
+func set_player(p: Player) -> void:
+	player = p
+
+
+## Set input handler reference
+func set_input_handler(handler) -> void:
+	input_handler = handler
+
+
+## Check if any screen is open
+func is_screen_open() -> bool:
+	return current_screen != ""
+
+
+## Get currently open screen name
+func get_current_screen() -> String:
+	return current_screen
+
+
+## Close any open screen
+func close_current_screen() -> void:
+	if current_screen.is_empty():
+		return
+
+	var screen = screens.get(current_screen)
+	if screen:
+		screen.hide()
+
+	var closed_screen = current_screen
+	current_screen = ""
+
+	_set_input_blocking(false)
+	screen_closed.emit(closed_screen)
+
+
+# =============================================================================
+# SCREEN OPENERS
+# =============================================================================
+
+## Open inventory screen
+func open_inventory() -> void:
+	if not _can_open_screen("inventory"):
+		return
+
+	var screen = screens.get("inventory")
+	if screen == null:
+		return
+
+	if screen.has_method("set_player"):
+		screen.set_player(player)
+
+	_open_screen("inventory")
+
+
+## Open character sheet
+func open_character_sheet() -> void:
+	if not _can_open_screen("character_sheet"):
+		return
+
+	var screen = screens.get("character_sheet")
+	if screen == null:
+		return
+
+	if screen.has_method("set_player"):
+		screen.set_player(player)
+
+	_open_screen("character_sheet")
+
+
+## Open crafting screen
+func open_crafting() -> void:
+	if not _can_open_screen("crafting"):
+		return
+
+	var screen = screens.get("crafting")
+	if screen == null:
+		return
+
+	if screen.has_method("set_player"):
+		screen.set_player(player)
+
+	_open_screen("crafting")
+
+
+## Open help screen
+func open_help() -> void:
+	if not _can_open_screen("help"):
+		return
+	_open_screen("help")
+
+
+## Open spell list screen
+func open_spell_list() -> void:
+	if not _can_open_screen("spell_list"):
+		return
+
+	var screen = screens.get("spell_list")
+	if screen == null:
+		return
+
+	if screen.has_method("set_player"):
+		screen.set_player(player)
+
+	_open_screen("spell_list")
+
+
+## Open ritual screen
+func open_rituals() -> void:
+	if not _can_open_screen("ritual"):
+		return
+
+	var screen = screens.get("ritual")
+	if screen == null:
+		return
+
+	if screen.has_method("set_player"):
+		screen.set_player(player)
+
+	_open_screen("ritual")
+
+
+## Open special actions screen
+func open_special_actions() -> void:
+	if not _can_open_screen("special_actions"):
+		return
+
+	var screen = screens.get("special_actions")
+	if screen == null:
+		return
+
+	if screen.has_method("set_player"):
+		screen.set_player(player)
+
+	_open_screen("special_actions")
+
+
+## Open world map screen
+func open_world_map() -> void:
+	if not _can_open_screen("world_map"):
+		return
+
+	var screen = screens.get("world_map")
+	if screen == null:
+		return
+
+	if screen.has_method("set_player"):
+		screen.set_player(player)
+	if screen.has_method("center_on_player"):
+		screen.center_on_player()
+
+	_open_screen("world_map")
+
+
+## Open level up screen
+func open_level_up() -> void:
+	if not _can_open_screen("level_up"):
+		return
+
+	var screen = screens.get("level_up")
+	if screen == null:
+		return
+
+	if screen.has_method("set_player"):
+		screen.set_player(player)
+
+	_open_screen("level_up")
+
+
+## Open shop screen with NPC
+func open_shop(npc) -> void:
+	if not _can_open_screen("shop"):
+		return
+
+	var screen = screens.get("shop")
+	if screen == null:
+		return
+
+	if screen.has_method("set_player"):
+		screen.set_player(player)
+	if screen.has_method("set_shop_npc"):
+		screen.set_shop_npc(npc)
+
+	_open_screen("shop")
+
+
+## Open container screen
+func open_container(container) -> void:
+	if not _can_open_screen("container"):
+		return
+
+	var screen = screens.get("container")
+	if screen == null:
+		return
+
+	if screen.has_method("set_player"):
+		screen.set_player(player)
+	if screen.has_method("set_container"):
+		screen.set_container(container)
+
+	_open_screen("container")
+
+
+## Open debug command menu
+func open_debug_menu() -> void:
+	if not _can_open_screen("debug_menu"):
+		return
+
+	var screen = screens.get("debug_menu")
+	if screen == null:
+		return
+
+	if screen.has_method("set_player"):
+		screen.set_player(player)
+
+	_open_screen("debug_menu")
+
+
+# =============================================================================
+# INTERNAL HELPERS
+# =============================================================================
+
+## Check if a screen can be opened
+func _can_open_screen(screen_name: String) -> bool:
+	# Close current screen first if different
+	if current_screen == screen_name:
+		close_current_screen()
+		return false
+
+	if not current_screen.is_empty():
+		close_current_screen()
+
+	return screens.has(screen_name)
+
+
+## Actually open a screen
+func _open_screen(screen_name: String) -> void:
+	var screen = screens.get(screen_name)
+	if screen == null:
+		return
+
+	current_screen = screen_name
+	screen.show()
+	_set_input_blocking(true)
+	screen_opened.emit(screen_name)
+
+
+## Handle screen closed signal
+func _on_screen_closed(screen_name: String) -> void:
+	if current_screen == screen_name:
+		current_screen = ""
+		_set_input_blocking(false)
+		screen_closed.emit(screen_name)
+
+
+## Set input blocking state
+func _set_input_blocking(blocking: bool) -> void:
+	if input_handler and input_handler.has_method("set_ui_blocking"):
+		input_handler.set_ui_blocking(blocking)
+
+
+# =============================================================================
+# SCREEN CONFIGURATION
+# =============================================================================
+
+## Get list of all registered screens
+func get_registered_screens() -> Array[String]:
+	var names: Array[String] = []
+	for name in screens:
+		names.append(name)
+	return names
+
+
+## Check if a screen is registered
+func has_screen(name: String) -> bool:
+	return name in screens
+
+
+## Get screen node by name
+func get_screen(name: String) -> Control:
+	return screens.get(name)
+```
+
+---
+
+### Step 2: Update scenes/game.gd
+
+1. **Add UICoordinator instance**:
+```gdscript
+const UICoordinatorClass = preload("res://systems/ui_coordinator.gd")
+
+var ui_coordinator: UICoordinator = null
+```
+
+2. **Initialize in `_ready()`**:
+```gdscript
+func _ready() -> void:
+	# ... existing initialization ...
+
+	# Initialize UI coordinator
+	ui_coordinator = UICoordinatorClass.new()
+	ui_coordinator.set_player(player)
+	ui_coordinator.set_input_handler(input_handler)
+
+	# Register screens
+	_register_ui_screens()
+
+	# Connect UI coordinator signals
+	ui_coordinator.screen_opened.connect(_on_ui_screen_opened)
+	ui_coordinator.screen_closed.connect(_on_ui_screen_closed)
+```
+
+3. **Add screen registration method**:
+```gdscript
+func _register_ui_screens() -> void:
+	ui_coordinator.register_screen("inventory", $UI/InventoryScreen)
+	ui_coordinator.register_screen("character_sheet", $UI/CharacterSheet)
+	ui_coordinator.register_screen("crafting", $UI/CraftingScreen)
+	ui_coordinator.register_screen("help", $UI/HelpScreen)
+	ui_coordinator.register_screen("shop", $UI/ShopScreen)
+	ui_coordinator.register_screen("container", $UI/ContainerScreen)
+	ui_coordinator.register_screen("level_up", $UI/LevelUpScreen)
+	ui_coordinator.register_screen("spell_list", $UI/SpellListScreen)
+	ui_coordinator.register_screen("ritual", $UI/RitualScreen)
+	ui_coordinator.register_screen("special_actions", $UI/SpecialActionsScreen)
+	ui_coordinator.register_screen("world_map", $UI/WorldMapScreen)
+	ui_coordinator.register_screen("debug_menu", $UI/DebugCommandMenu)
+```
+
+4. **Simplify key handlers** to use coordinator:
+```gdscript
+# Before:
+func _on_inventory_key_pressed() -> void:
+	if inventory_screen.visible:
+		_close_inventory()
+	else:
+		_setup_inventory_screen()
+		inventory_screen.show()
+		input_handler.set_ui_blocking(true)
+
+# After:
+func _on_inventory_key_pressed() -> void:
+	ui_coordinator.open_inventory()
+```
+
+5. **Add thin wrapper signals** (if needed by other systems):
+```gdscript
+func _on_ui_screen_opened(screen_name: String) -> void:
+	# Any game-specific logic when screens open
+	pass
+
+func _on_ui_screen_closed(screen_name: String) -> void:
+	# Any game-specific logic when screens close
+	# E.g., refresh display, resume gameplay
+	_request_full_render()
+```
+
+6. **Remove old `_setup_*_screen()` methods** - coordinator handles this.
+
+7. **Remove old `_on_*_closed()` methods** - coordinator handles this.
+
+---
+
+## Files Summary
+
+### New Files
+- `systems/ui_coordinator.gd` (~300 lines)
+
+### Modified Files
+- `scenes/game.gd` - Reduced by ~600 lines
+
+---
+
+## Verification Checklist
+
+After completing all changes:
+
+- [ ] Game launches without errors
+- [ ] Inventory (I key)
+  - [ ] Opens correctly
+  - [ ] Shows player items
+  - [ ] Closes with Escape or I
+- [ ] Character Sheet (C key)
+  - [ ] Opens correctly
+  - [ ] Shows player stats
+  - [ ] Closes correctly
+- [ ] Crafting (R key)
+  - [ ] Opens correctly
+  - [ ] Shows recipes
+  - [ ] Closes correctly
+- [ ] Help (? key)
+  - [ ] Opens correctly
+  - [ ] Shows keybindings
+  - [ ] Closes correctly
+- [ ] Spell List (Z key)
+  - [ ] Opens correctly
+  - [ ] Shows known spells
+  - [ ] Closes correctly
+- [ ] World Map (M key)
+  - [ ] Opens correctly
+  - [ ] Shows explored areas
+  - [ ] Closes correctly
+- [ ] Shop (interact with merchant)
+  - [ ] Opens correctly
+  - [ ] Shows items
+  - [ ] Closes correctly
+- [ ] Container (open chest)
+  - [ ] Opens correctly
+  - [ ] Shows contents
+  - [ ] Closes correctly
+- [ ] Debug Menu (F12)
+  - [ ] Opens correctly
+  - [ ] Commands work
+  - [ ] Closes correctly
+- [ ] Opening one screen closes another
+- [ ] Input blocking works correctly
+- [ ] Game rendering updates after closing screens
+- [ ] No new console warnings/errors
+
+---
+
+## Rollback
+
+If issues occur:
+```bash
+git checkout HEAD -- scenes/game.gd
+rm systems/ui_coordinator.gd
+```
+
+Or revert entire commit:
+```bash
+git revert HEAD
+```

--- a/plans/features/v1.7/refactor-12-game-event-handlers.md
+++ b/plans/features/v1.7/refactor-12-game-event-handlers.md
@@ -1,0 +1,533 @@
+# Refactor 12: Game Event Handlers
+
+**Risk Level**: High
+**Estimated Changes**: 1 new file, 1 file partially reduced
+**Dependency**: Must complete Plan 11 first
+
+---
+
+## Goal
+
+Extract EventBus signal handlers from `game.gd` into a dedicated `GameEventHandlers` class.
+
+This is the second of three plans to decompose game.gd. Focus on:
+- All `_on_*` signal handlers connected to EventBus
+- Signal subscription management
+- Event routing and response logic
+
+---
+
+## Current State
+
+### scenes/game.gd EventBus Connections
+
+game.gd connects to 60+ EventBus signals in `_ready()`:
+
+```gdscript
+EventBus.player_moved.connect(_on_player_moved)
+EventBus.entity_moved.connect(_on_entity_moved)
+EventBus.entity_died.connect(_on_entity_died)
+EventBus.attack_performed.connect(_on_attack_performed)
+EventBus.item_picked_up.connect(_on_item_picked_up)
+EventBus.item_dropped.connect(_on_item_dropped)
+EventBus.inventory_changed.connect(_on_inventory_changed)
+EventBus.player_health_changed.connect(_on_player_health_changed)
+EventBus.player_mana_changed.connect(_on_player_mana_changed)
+EventBus.player_stamina_changed.connect(_on_player_stamina_changed)
+EventBus.survival_warning.connect(_on_survival_warning)
+EventBus.message_logged.connect(_on_message_logged)
+EventBus.turn_advanced.connect(_on_turn_advanced)
+EventBus.level_up_available.connect(_on_level_up_available)
+# ... and 40+ more
+```
+
+Each connection has a corresponding handler method (~15-50 lines each).
+
+---
+
+## Implementation
+
+### Step 1: Create systems/game_event_handlers.gd
+
+```gdscript
+class_name GameEventHandlers
+extends RefCounted
+
+## GameEventHandlers - Manages EventBus signal subscriptions for game scene
+##
+## Centralizes event handling logic extracted from game.gd.
+## Provides cleaner separation between event routing and game logic.
+
+# Callbacks to game.gd for actions that need scene access
+signal request_render_update()
+signal request_hud_update()
+signal request_message_display(text: String)
+signal request_full_render()
+
+# Game references
+var game_scene = null
+var player: Player = null
+var renderer = null
+
+
+func _init() -> void:
+	pass
+
+
+## Initialize with game scene reference
+func setup(scene, p: Player, rend) -> void:
+	game_scene = scene
+	player = p
+	renderer = rend
+
+
+## Connect all EventBus signals
+func connect_signals() -> void:
+	# Movement
+	EventBus.player_moved.connect(_on_player_moved)
+	EventBus.entity_moved.connect(_on_entity_moved)
+
+	# Combat
+	EventBus.attack_performed.connect(_on_attack_performed)
+	EventBus.entity_died.connect(_on_entity_died)
+	EventBus.damage_dealt.connect(_on_damage_dealt)
+
+	# Items
+	EventBus.item_picked_up.connect(_on_item_picked_up)
+	EventBus.item_dropped.connect(_on_item_dropped)
+	EventBus.inventory_changed.connect(_on_inventory_changed)
+	EventBus.item_equipped.connect(_on_item_equipped)
+	EventBus.item_unequipped.connect(_on_item_unequipped)
+
+	# Player stats
+	EventBus.player_health_changed.connect(_on_player_health_changed)
+	EventBus.player_mana_changed.connect(_on_player_mana_changed)
+	EventBus.player_stamina_changed.connect(_on_player_stamina_changed)
+	EventBus.player_stats_changed.connect(_on_player_stats_changed)
+	EventBus.gold_changed.connect(_on_gold_changed)
+
+	# Survival
+	EventBus.survival_warning.connect(_on_survival_warning)
+	EventBus.hunger_changed.connect(_on_hunger_changed)
+	EventBus.thirst_changed.connect(_on_thirst_changed)
+	EventBus.temperature_changed.connect(_on_temperature_changed)
+
+	# Turn and time
+	EventBus.turn_advanced.connect(_on_turn_advanced)
+	EventBus.time_changed.connect(_on_time_changed)
+	EventBus.day_changed.connect(_on_day_changed)
+
+	# Map and world
+	EventBus.map_changed.connect(_on_map_changed)
+	EventBus.tile_changed.connect(_on_tile_changed)
+	EventBus.chunk_loaded.connect(_on_chunk_loaded)
+	EventBus.chunk_unloaded.connect(_on_chunk_unloaded)
+
+	# Features and hazards
+	EventBus.feature_interacted.connect(_on_feature_interacted)
+	EventBus.hazard_triggered.connect(_on_hazard_triggered)
+	EventBus.trap_detected.connect(_on_trap_detected)
+
+	# UI and feedback
+	EventBus.message_logged.connect(_on_message_logged)
+	EventBus.level_up_available.connect(_on_level_up_available)
+
+	# Magic
+	EventBus.spell_cast.connect(_on_spell_cast)
+	EventBus.ritual_performed.connect(_on_ritual_performed)
+	EventBus.concentration_broken.connect(_on_concentration_broken)
+
+	# Weather
+	EventBus.weather_changed.connect(_on_weather_changed)
+
+
+## Disconnect all signals (for cleanup)
+func disconnect_signals() -> void:
+	# Movement
+	if EventBus.player_moved.is_connected(_on_player_moved):
+		EventBus.player_moved.disconnect(_on_player_moved)
+	# ... repeat for all signals
+
+
+# =============================================================================
+# MOVEMENT HANDLERS
+# =============================================================================
+
+func _on_player_moved(new_position: Vector2i) -> void:
+	# Update FOV
+	if player:
+		player.update_fov()
+
+	# Request render update
+	request_render_update.emit()
+	request_hud_update.emit()
+
+
+func _on_entity_moved(entity: Entity, old_pos: Vector2i, new_pos: Vector2i) -> void:
+	# Mark tiles dirty for rendering
+	if renderer:
+		renderer.mark_entity_dirty(old_pos)
+		renderer.mark_entity_dirty(new_pos)
+
+
+# =============================================================================
+# COMBAT HANDLERS
+# =============================================================================
+
+func _on_attack_performed(attacker: Entity, defender: Entity, damage: int, hit: bool) -> void:
+	if not hit:
+		request_message_display.emit("%s misses %s!" % [attacker.display_name, defender.display_name])
+		return
+
+	var msg = "%s hits %s for %d damage!" % [attacker.display_name, defender.display_name, damage]
+	request_message_display.emit(msg)
+
+	# Flash effect could be triggered here
+	if renderer and defender:
+		renderer.flash_tile(defender.position, Color.RED)
+
+
+func _on_entity_died(entity: Entity, killer: Entity) -> void:
+	var msg = "%s has been slain" % entity.display_name
+	if killer:
+		msg += " by %s" % killer.display_name
+	msg += "!"
+
+	request_message_display.emit(msg)
+
+	# Grant XP if player killed it
+	if killer == player and entity is Enemy:
+		var xp = entity.xp_value if "xp_value" in entity else 10
+		player.gain_experience(xp)
+		request_message_display.emit("Gained %d XP" % xp)
+
+	request_render_update.emit()
+
+
+func _on_damage_dealt(source: Entity, target: Entity, amount: int, damage_type: String) -> void:
+	# Could show floating damage numbers, play sounds, etc.
+	pass
+
+
+# =============================================================================
+# ITEM HANDLERS
+# =============================================================================
+
+func _on_item_picked_up(item: Item, entity: Entity) -> void:
+	if entity == player:
+		var msg = "Picked up %s" % item.display_name
+		if item.stack_count > 1:
+			msg += " (x%d)" % item.stack_count
+		request_message_display.emit(msg)
+
+	request_render_update.emit()
+
+
+func _on_item_dropped(item: Item, position: Vector2i) -> void:
+	request_message_display.emit("Dropped %s" % item.display_name)
+	request_render_update.emit()
+
+
+func _on_inventory_changed() -> void:
+	request_hud_update.emit()
+
+
+func _on_item_equipped(item: Item, slot: String) -> void:
+	request_message_display.emit("Equipped %s" % item.display_name)
+	request_hud_update.emit()
+
+
+func _on_item_unequipped(item: Item, slot: String) -> void:
+	request_message_display.emit("Unequipped %s" % item.display_name)
+	request_hud_update.emit()
+
+
+# =============================================================================
+# PLAYER STAT HANDLERS
+# =============================================================================
+
+func _on_player_health_changed(current: int, maximum: int) -> void:
+	request_hud_update.emit()
+
+	# Low health warning
+	if current <= maximum * 0.25:
+		request_message_display.emit("Warning: Health critical!")
+
+
+func _on_player_mana_changed(current: int, maximum: int) -> void:
+	request_hud_update.emit()
+
+
+func _on_player_stamina_changed(current: int, maximum: int) -> void:
+	request_hud_update.emit()
+
+	if current <= 10:
+		request_message_display.emit("You're exhausted!")
+
+
+func _on_player_stats_changed() -> void:
+	request_hud_update.emit()
+
+
+func _on_gold_changed(new_amount: int) -> void:
+	request_hud_update.emit()
+
+
+# =============================================================================
+# SURVIVAL HANDLERS
+# =============================================================================
+
+func _on_survival_warning(warning_type: String, severity: String) -> void:
+	var messages = {
+		"hunger_mild": "You're getting hungry.",
+		"hunger_moderate": "You're very hungry!",
+		"hunger_severe": "You're starving!",
+		"thirst_mild": "You're getting thirsty.",
+		"thirst_moderate": "You're very thirsty!",
+		"thirst_severe": "You're dying of thirst!",
+		"cold_mild": "You're getting cold.",
+		"cold_severe": "You're freezing!",
+		"heat_mild": "You're getting hot.",
+		"heat_severe": "You're overheating!",
+	}
+
+	var key = "%s_%s" % [warning_type, severity]
+	if key in messages:
+		request_message_display.emit(messages[key])
+
+
+func _on_hunger_changed(value: float) -> void:
+	request_hud_update.emit()
+
+
+func _on_thirst_changed(value: float) -> void:
+	request_hud_update.emit()
+
+
+func _on_temperature_changed(value: float) -> void:
+	request_hud_update.emit()
+
+
+# =============================================================================
+# TURN AND TIME HANDLERS
+# =============================================================================
+
+func _on_turn_advanced(turn_number: int) -> void:
+	# Update any turn-based displays
+	request_hud_update.emit()
+
+
+func _on_time_changed(hour: int, minute: int) -> void:
+	request_hud_update.emit()
+
+
+func _on_day_changed(day: int) -> void:
+	request_message_display.emit("A new day begins.")
+
+
+# =============================================================================
+# MAP HANDLERS
+# =============================================================================
+
+func _on_map_changed(new_map) -> void:
+	request_full_render.emit()
+
+
+func _on_tile_changed(position: Vector2i) -> void:
+	if renderer:
+		renderer.mark_terrain_dirty(position)
+
+
+func _on_chunk_loaded(chunk_coords: Vector2i) -> void:
+	request_render_update.emit()
+
+
+func _on_chunk_unloaded(chunk_coords: Vector2i) -> void:
+	# Cleanup handled by managers
+	pass
+
+
+# =============================================================================
+# FEATURE AND HAZARD HANDLERS
+# =============================================================================
+
+func _on_feature_interacted(feature, entity: Entity) -> void:
+	# Log interaction
+	if feature and "name" in feature:
+		request_message_display.emit("Interacted with %s" % feature.name)
+
+
+func _on_hazard_triggered(hazard, entity: Entity, damage: int) -> void:
+	if entity == player:
+		var hazard_name = hazard.name if hazard and "name" in hazard else "trap"
+		request_message_display.emit("You triggered a %s! (%d damage)" % [hazard_name, damage])
+
+
+func _on_trap_detected(position: Vector2i, hazard_id: String) -> void:
+	request_message_display.emit("You notice a trap!")
+	if renderer:
+		renderer.mark_terrain_dirty(position)
+
+
+# =============================================================================
+# UI HANDLERS
+# =============================================================================
+
+func _on_message_logged(text: String) -> void:
+	request_message_display.emit(text)
+
+
+func _on_level_up_available() -> void:
+	request_message_display.emit("Level up available! Press 'L' to level up.")
+
+
+# =============================================================================
+# MAGIC HANDLERS
+# =============================================================================
+
+func _on_spell_cast(caster: Entity, spell, target) -> void:
+	if caster == player:
+		request_message_display.emit("Cast %s" % spell.name)
+	request_render_update.emit()
+
+
+func _on_ritual_performed(performer: Entity, ritual) -> void:
+	if performer == player:
+		request_message_display.emit("Performed ritual: %s" % ritual.name)
+
+
+func _on_concentration_broken(entity: Entity, spell, reason: String) -> void:
+	if entity == player:
+		request_message_display.emit("Concentration broken: %s" % reason)
+
+
+# =============================================================================
+# WEATHER HANDLERS
+# =============================================================================
+
+func _on_weather_changed(weather_type: String) -> void:
+	var weather_messages = {
+		"clear": "The weather clears up.",
+		"rain": "It starts to rain.",
+		"storm": "A storm rolls in!",
+		"snow": "Snow begins to fall.",
+		"fog": "A thick fog settles in.",
+	}
+
+	if weather_type in weather_messages:
+		request_message_display.emit(weather_messages[weather_type])
+
+	request_render_update.emit()
+```
+
+---
+
+### Step 2: Update scenes/game.gd
+
+1. **Add GameEventHandlers instance**:
+```gdscript
+const GameEventHandlersClass = preload("res://systems/game_event_handlers.gd")
+
+var event_handlers: GameEventHandlers = null
+```
+
+2. **Initialize in `_ready()`**:
+```gdscript
+func _ready() -> void:
+	# ... existing initialization ...
+
+	# Initialize event handlers
+	event_handlers = GameEventHandlersClass.new()
+	event_handlers.setup(self, player, renderer)
+
+	# Connect handler signals to game methods
+	event_handlers.request_render_update.connect(_on_request_render_update)
+	event_handlers.request_hud_update.connect(_on_request_hud_update)
+	event_handlers.request_message_display.connect(_on_request_message_display)
+	event_handlers.request_full_render.connect(_on_request_full_render)
+
+	# Connect EventBus signals
+	event_handlers.connect_signals()
+```
+
+3. **Add thin wrapper methods**:
+```gdscript
+func _on_request_render_update() -> void:
+	_render_entities()
+	_render_ground_items()
+
+func _on_request_hud_update() -> void:
+	_update_hud()
+
+func _on_request_message_display(text: String) -> void:
+	_add_message(text)
+
+func _on_request_full_render() -> void:
+	_render_all()
+```
+
+4. **Remove old `_on_*` EventBus handlers** - now in GameEventHandlers.
+
+---
+
+## Files Summary
+
+### New Files
+- `systems/game_event_handlers.gd` (~400 lines)
+
+### Modified Files
+- `scenes/game.gd` - Reduced by ~800 lines
+
+---
+
+## Verification Checklist
+
+After completing all changes:
+
+- [ ] Game launches without errors
+- [ ] Movement events
+  - [ ] Player movement updates view
+  - [ ] FOV updates on movement
+- [ ] Combat events
+  - [ ] Attack messages display
+  - [ ] Death messages display
+  - [ ] XP gain messages
+- [ ] Item events
+  - [ ] Pickup messages
+  - [ ] Drop messages
+  - [ ] Equip/unequip messages
+- [ ] Stat changes
+  - [ ] Health changes update HUD
+  - [ ] Low health warning appears
+  - [ ] Stamina exhaustion warning
+- [ ] Survival events
+  - [ ] Hunger warnings
+  - [ ] Thirst warnings
+  - [ ] Temperature warnings
+- [ ] Turn/time events
+  - [ ] Day change message
+  - [ ] HUD updates on turn
+- [ ] Map events
+  - [ ] Map transition renders correctly
+  - [ ] Chunk loading works
+- [ ] Magic events
+  - [ ] Spell cast messages
+  - [ ] Concentration broken messages
+- [ ] Weather events
+  - [ ] Weather change messages
+- [ ] No new console warnings/errors
+
+---
+
+## Rollback
+
+If issues occur:
+```bash
+git checkout HEAD -- scenes/game.gd
+rm systems/game_event_handlers.gd
+```
+
+Or revert entire commit:
+```bash
+git revert HEAD
+```

--- a/plans/features/v1.7/refactor-13-game-rendering-orchestrator.md
+++ b/plans/features/v1.7/refactor-13-game-rendering-orchestrator.md
@@ -1,0 +1,633 @@
+# Refactor 13: Game Rendering Orchestrator
+
+**Risk Level**: High
+**Estimated Changes**: 1 new file, 1 file significantly reduced
+**Dependencies**: Must complete Plans 11 and 12 first
+
+---
+
+## Goal
+
+Extract rendering orchestration from `game.gd` into a dedicated `RenderingOrchestrator` class.
+
+This is the final plan to decompose game.gd. Focus on:
+- All `_render_*` methods
+- Visibility and FOV coordination
+- Light source management
+- Dirty flag management
+- Chunk rendering coordination
+
+---
+
+## Current State
+
+### scenes/game.gd Rendering Code (~800 lines)
+
+**Render Methods:**
+- `_render_all()` - Full scene render
+- `_render_map()` / `_render_terrain()` - Terrain tiles
+- `_render_entities()` / `_render_entity_at()` - All entities
+- `_render_ground_items()` - Items on ground
+- `_render_features()` - Doors, chests, etc.
+- `_render_hazards()` - Traps, etc.
+- `_render_player()` - Player character
+
+**Visibility Methods:**
+- `_update_visibility()` - FOV calculation coordination
+- `_apply_fog_of_war()` - FOW rendering
+
+**Light Source Methods:**
+- `_initialize_light_sources_for_map()` - Setup light sources
+- `_update_dynamic_light_sources()` - Torch, campfire updates
+- `_rebuild_enemy_light_cache()` - Enemy visibility from lights
+
+**Dirty Flag Management:**
+- `_mark_terrain_dirty()`
+- `_mark_entity_dirty()`
+- `_request_full_render()`
+
+---
+
+## Implementation
+
+### Step 1: Create systems/rendering_orchestrator.gd
+
+```gdscript
+class_name RenderingOrchestrator
+extends RefCounted
+
+## RenderingOrchestrator - Coordinates game rendering
+##
+## Manages rendering pipeline, visibility, and light sources.
+## Extracted from game.gd to improve organization.
+
+# Renderer reference
+var renderer = null
+
+# Game references
+var player: Player = null
+var current_map = null
+
+# Dirty tracking
+var _terrain_dirty: bool = true
+var _entities_dirty: bool = true
+var _items_dirty: bool = true
+var _full_render_requested: bool = true
+
+# Light source tracking
+var _static_light_sources: Array = []
+var _dynamic_light_sources: Array = []
+
+
+func _init() -> void:
+	pass
+
+
+## Setup with renderer and player
+func setup(rend, p: Player) -> void:
+	renderer = rend
+	player = p
+
+
+## Set current map reference
+func set_map(map) -> void:
+	current_map = map
+	_full_render_requested = true
+	_initialize_light_sources()
+
+
+# =============================================================================
+# RENDER REQUESTS
+# =============================================================================
+
+## Request full render (map change, etc.)
+func request_full_render() -> void:
+	_full_render_requested = true
+
+
+## Mark terrain as needing re-render
+func mark_terrain_dirty(position: Vector2i = Vector2i(-1, -1)) -> void:
+	_terrain_dirty = true
+	if renderer and position != Vector2i(-1, -1):
+		renderer.mark_terrain_dirty(position)
+
+
+## Mark entities as needing re-render
+func mark_entities_dirty() -> void:
+	_entities_dirty = true
+
+
+## Mark ground items as needing re-render
+func mark_items_dirty() -> void:
+	_items_dirty = true
+
+
+# =============================================================================
+# MAIN RENDER
+# =============================================================================
+
+## Perform render (called each frame or on demand)
+func render() -> void:
+	if renderer == null or current_map == null:
+		return
+
+	# Full render if requested
+	if _full_render_requested:
+		_render_all()
+		_full_render_requested = false
+		_terrain_dirty = false
+		_entities_dirty = false
+		_items_dirty = false
+		return
+
+	# Incremental render
+	if _terrain_dirty:
+		_render_terrain()
+		_terrain_dirty = false
+
+	if _items_dirty:
+		_render_ground_items()
+		_items_dirty = false
+
+	if _entities_dirty:
+		_render_entities()
+		_entities_dirty = false
+
+
+## Full scene render
+func _render_all() -> void:
+	_update_visibility()
+	_render_terrain()
+	_render_features()
+	_render_hazards()
+	_render_ground_items()
+	_render_entities()
+	_render_player()
+	_apply_fog_of_war()
+
+
+# =============================================================================
+# TERRAIN RENDERING
+# =============================================================================
+
+## Render terrain tiles
+func _render_terrain() -> void:
+	if renderer == null or current_map == null:
+		return
+
+	renderer.clear_terrain_layer()
+
+	# Get visible area
+	var visible_tiles = _get_visible_tiles()
+
+	for pos in visible_tiles:
+		var tile = current_map.get_tile_at(pos)
+		if tile:
+			renderer.render_terrain_tile(pos, tile)
+
+
+## Get tiles visible to player
+func _get_visible_tiles() -> Array[Vector2i]:
+	if player == null:
+		return []
+
+	return player.get_visible_tiles()
+
+
+# =============================================================================
+# ENTITY RENDERING
+# =============================================================================
+
+## Render all entities
+func _render_entities() -> void:
+	if renderer == null:
+		return
+
+	renderer.clear_entity_layer()
+
+	var visible_tiles = _get_visible_tiles()
+
+	# Render enemies and NPCs
+	for entity in EntityManager.entities:
+		if entity.position in visible_tiles:
+			_render_entity(entity)
+
+	# Render summons
+	if player and player.has_method("get_summons"):
+		for summon in player.get_summons():
+			if summon.position in visible_tiles:
+				_render_entity(summon)
+
+
+## Render single entity
+func _render_entity(entity: Entity) -> void:
+	if renderer == null or entity == null:
+		return
+
+	var symbol = entity.symbol if "symbol" in entity else "?"
+	var color = entity.color if "color" in entity else Color.WHITE
+
+	# Modify color for status effects
+	if "is_summoned" in entity and entity.is_summoned:
+		color = color.lerp(Color.CYAN, 0.3)
+
+	renderer.render_entity(entity.position, symbol, color)
+
+
+## Render player
+func _render_player() -> void:
+	if renderer == null or player == null:
+		return
+
+	var color = Color.WHITE
+
+	# Status-based color modifications
+	if player.hp <= player.max_hp * 0.25:
+		color = Color.RED
+	elif player.hp <= player.max_hp * 0.5:
+		color = Color.YELLOW
+
+	renderer.render_entity(player.position, "@", color)
+
+
+# =============================================================================
+# ITEM RENDERING
+# =============================================================================
+
+## Render ground items
+func _render_ground_items() -> void:
+	if renderer == null or current_map == null:
+		return
+
+	renderer.clear_item_layer()
+
+	var visible_tiles = _get_visible_tiles()
+
+	for pos in visible_tiles:
+		var items = current_map.get_items_at(pos)
+		if items.size() > 0:
+			_render_ground_item(pos, items)
+
+
+## Render item pile at position
+func _render_ground_item(position: Vector2i, items: Array) -> void:
+	if renderer == null:
+		return
+
+	# Show top item or pile indicator
+	if items.size() == 1:
+		var item = items[0]
+		var symbol = item.symbol if "symbol" in item else "!"
+		var color = item.color if "color" in item else Color.WHITE
+		renderer.render_item(position, symbol, color)
+	else:
+		# Multiple items - show pile
+		renderer.render_item(position, "&", Color.YELLOW)
+
+
+# =============================================================================
+# FEATURE RENDERING
+# =============================================================================
+
+## Render features (doors, chests, etc.)
+func _render_features() -> void:
+	if renderer == null:
+		return
+
+	var visible_tiles = _get_visible_tiles()
+
+	for pos in FeatureManager.placed_features:
+		if pos in visible_tiles:
+			var feature = FeatureManager.placed_features[pos]
+			_render_feature(pos, feature)
+
+
+## Render single feature
+func _render_feature(position: Vector2i, feature) -> void:
+	if renderer == null or feature == null:
+		return
+
+	var symbol = feature.get("symbol", "?")
+	var color = feature.get("color", Color.WHITE)
+
+	# State-based symbol changes
+	if feature.get("is_open", false):
+		symbol = feature.get("open_symbol", "'")
+	if feature.get("is_locked", false):
+		color = Color.YELLOW
+
+	renderer.render_feature(position, symbol, color)
+
+
+# =============================================================================
+# HAZARD RENDERING
+# =============================================================================
+
+## Render hazards (traps)
+func _render_hazards() -> void:
+	if renderer == null:
+		return
+
+	var visible_tiles = _get_visible_tiles()
+
+	for pos in HazardManager.active_hazards:
+		if pos in visible_tiles:
+			var hazard = HazardManager.active_hazards[pos]
+			_render_hazard(pos, hazard)
+
+
+## Render single hazard
+func _render_hazard(position: Vector2i, hazard) -> void:
+	if renderer == null or hazard == null:
+		return
+
+	# Only render if detected
+	if not hazard.get("detected", false):
+		return
+
+	var symbol = hazard.get("symbol", "^")
+	var color = hazard.get("color", Color.RED)
+
+	renderer.render_hazard(position, symbol, color)
+
+
+# =============================================================================
+# VISIBILITY AND FOG OF WAR
+# =============================================================================
+
+## Update visibility (FOV calculation)
+func _update_visibility() -> void:
+	if player == null:
+		return
+
+	player.update_fov()
+
+
+## Apply fog of war effect
+func _apply_fog_of_war() -> void:
+	if renderer == null or current_map == null or player == null:
+		return
+
+	# Get explored but not visible tiles
+	var explored = current_map.explored_tiles if "explored_tiles" in current_map else []
+	var visible = _get_visible_tiles()
+
+	for pos in explored:
+		if pos not in visible:
+			renderer.apply_fog_of_war(pos)
+
+
+# =============================================================================
+# LIGHT SOURCES
+# =============================================================================
+
+## Initialize light sources for current map
+func _initialize_light_sources() -> void:
+	_static_light_sources.clear()
+	_dynamic_light_sources.clear()
+
+	if current_map == null:
+		return
+
+	# Find static light sources (torches on walls, etc.)
+	for pos in FeatureManager.placed_features:
+		var feature = FeatureManager.placed_features[pos]
+		if feature.get("emits_light", false):
+			_static_light_sources.append({
+				"position": pos,
+				"radius": feature.get("light_radius", 3),
+				"color": feature.get("light_color", Color.ORANGE)
+			})
+
+	# Dynamic sources handled separately (player torch, campfires)
+
+
+## Update dynamic light sources
+func update_light_sources() -> void:
+	_dynamic_light_sources.clear()
+
+	# Player torch
+	if player and player.has_method("has_light_source"):
+		if player.has_light_source():
+			_dynamic_light_sources.append({
+				"position": player.position,
+				"radius": player.get_light_radius(),
+				"color": Color.ORANGE
+			})
+
+	# Active campfires
+	for pos in StructureManager.placed_structures:
+		var structure = StructureManager.placed_structures[pos]
+		if structure.get("type") == "campfire" and structure.get("is_active", false):
+			_dynamic_light_sources.append({
+				"position": pos,
+				"radius": 5,
+				"color": Color.ORANGE
+			})
+
+
+## Get all light sources
+func get_all_light_sources() -> Array:
+	var all_sources = _static_light_sources.duplicate()
+	all_sources.append_array(_dynamic_light_sources)
+	return all_sources
+
+
+## Check if position is lit
+func is_position_lit(position: Vector2i) -> bool:
+	for source in get_all_light_sources():
+		var dist = position.distance_to(source.position)
+		if dist <= source.radius:
+			return true
+	return false
+
+
+# =============================================================================
+# UTILITY
+# =============================================================================
+
+## Center view on player
+func center_view_on_player() -> void:
+	if renderer == null or player == null:
+		return
+
+	if renderer.has_method("center_on"):
+		renderer.center_on(player.position)
+
+
+## Get render statistics (for debugging)
+func get_render_stats() -> Dictionary:
+	return {
+		"terrain_dirty": _terrain_dirty,
+		"entities_dirty": _entities_dirty,
+		"items_dirty": _items_dirty,
+		"full_render_pending": _full_render_requested,
+		"static_lights": _static_light_sources.size(),
+		"dynamic_lights": _dynamic_light_sources.size(),
+	}
+```
+
+---
+
+### Step 2: Update scenes/game.gd
+
+1. **Add RenderingOrchestrator instance**:
+```gdscript
+const RenderingOrchestratorClass = preload("res://systems/rendering_orchestrator.gd")
+
+var render_orchestrator: RenderingOrchestrator = null
+```
+
+2. **Initialize in `_ready()`**:
+```gdscript
+func _ready() -> void:
+	# ... existing initialization ...
+
+	# Initialize rendering orchestrator
+	render_orchestrator = RenderingOrchestratorClass.new()
+	render_orchestrator.setup(renderer, player)
+```
+
+3. **Update map changes** to use orchestrator:
+```gdscript
+func _on_map_loaded(map) -> void:
+	render_orchestrator.set_map(map)
+```
+
+4. **Simplify render calls**:
+```gdscript
+# Before:
+func _render_all() -> void:
+	_update_visibility()
+	_render_terrain()
+	_render_features()
+	# ... 50+ lines
+
+# After:
+func _render_all() -> void:
+	render_orchestrator.render()
+```
+
+5. **Update `_process()` or render triggers**:
+```gdscript
+func _process(delta: float) -> void:
+	# ... other processing ...
+	render_orchestrator.render()
+```
+
+6. **Update dirty marking**:
+```gdscript
+# Before (in event handlers):
+_mark_terrain_dirty(pos)
+
+# After:
+render_orchestrator.mark_terrain_dirty(pos)
+```
+
+7. **Remove old render methods** - now in RenderingOrchestrator:
+- `_render_all()`
+- `_render_terrain()`
+- `_render_entities()`
+- `_render_ground_items()`
+- `_render_features()`
+- `_render_hazards()`
+- `_render_player()`
+- `_update_visibility()`
+- `_apply_fog_of_war()`
+- `_initialize_light_sources_for_map()`
+- `_update_dynamic_light_sources()`
+- Dirty flag variables and methods
+
+---
+
+## Files Summary
+
+### New Files
+- `systems/rendering_orchestrator.gd` (~400 lines)
+
+### Modified Files
+- `scenes/game.gd` - Reduced from original 3,337 lines to ~1,000 lines
+
+---
+
+## Final game.gd Structure
+
+After all three plans (11, 12, 13), game.gd should contain only:
+- Scene initialization and setup
+- Node references
+- High-level game state management
+- Delegation to UICoordinator, GameEventHandlers, RenderingOrchestrator
+- Game loop coordination
+- Save/load triggers
+
+---
+
+## Verification Checklist
+
+After completing all changes:
+
+- [ ] Game launches without errors
+- [ ] Terrain rendering
+  - [ ] Walls, floors render correctly
+  - [ ] Water, grass, trees render
+  - [ ] Dungeon tiles render
+- [ ] Entity rendering
+  - [ ] Player (@) renders
+  - [ ] Enemies render with correct symbols
+  - [ ] NPCs render correctly
+  - [ ] Summons render (if any)
+- [ ] Item rendering
+  - [ ] Single items show symbol
+  - [ ] Item piles show (&)
+- [ ] Feature rendering
+  - [ ] Doors (+ and ')
+  - [ ] Chests (= and _)
+  - [ ] Stairs (< and >)
+- [ ] Hazard rendering
+  - [ ] Detected traps visible
+  - [ ] Undetected traps hidden
+- [ ] Visibility
+  - [ ] FOV works correctly
+  - [ ] Fog of war on explored tiles
+- [ ] Light sources
+  - [ ] Torch illumination
+  - [ ] Campfire illumination
+- [ ] Dirty flag optimization
+  - [ ] Partial renders work
+  - [ ] Full render on map change
+- [ ] Performance acceptable
+  - [ ] No lag during movement
+  - [ ] Smooth chunk transitions
+- [ ] No new console warnings/errors
+
+---
+
+## Rollback
+
+If issues occur:
+```bash
+git checkout HEAD -- scenes/game.gd
+rm systems/rendering_orchestrator.gd
+```
+
+Or revert entire commit:
+```bash
+git revert HEAD
+```
+
+---
+
+## Summary: game.gd Decomposition Complete
+
+After Plans 11, 12, and 13:
+
+| File | Lines |
+|------|-------|
+| scenes/game.gd (original) | 3,337 |
+| scenes/game.gd (final) | ~1,000 |
+| systems/ui_coordinator.gd | ~300 |
+| systems/game_event_handlers.gd | ~400 |
+| systems/rendering_orchestrator.gd | ~400 |
+
+Total extracted: ~2,300 lines
+Reduction: 70%

--- a/plans/features/v1.7/refactoring-overview.md
+++ b/plans/features/v1.7/refactoring-overview.md
@@ -1,0 +1,101 @@
+# V1.7 Refactoring Overview
+
+**Goal**: Improve code organization, apply DRY/SOLID principles, and make the codebase easier to maintain without breaking any existing functionality.
+
+---
+
+## Plan Index
+
+Execute these plans in order (lowest to highest risk):
+
+### Phase A: Utility Extraction (Zero Risk)
+| Plan | File | Description |
+|------|------|-------------|
+| 01 | [refactor-01-json-helper-extend.md](refactor-01-json-helper-extend.md) | Extend JsonHelper to eliminate duplicate JSON loading code |
+| 02 | [refactor-02-ui-theme-constants.md](refactor-02-ui-theme-constants.md) | Create centralized UI color constants |
+| 03 | [refactor-03-inventory-filter-constants.md](refactor-03-inventory-filter-constants.md) | Consolidate filter hotkey/label constants |
+
+### Phase B: Minor Extractions (Low Risk)
+| Plan | File | Description |
+|------|------|-------------|
+| 04 | [refactor-04-chunk-cleanup-mixin.md](refactor-04-chunk-cleanup-mixin.md) | Create shared chunk cleanup utility |
+| 05 | [refactor-05-input-mode-handlers.md](refactor-05-input-mode-handlers.md) | Extract input mode handlers |
+| 06 | [refactor-06-debug-command-executor.md](refactor-06-debug-command-executor.md) | Separate debug command execution from UI |
+
+### Phase C: Component Extraction (Medium Risk)
+| Plan | File | Description |
+|------|------|-------------|
+| 07 | [refactor-07-item-usage-handler.md](refactor-07-item-usage-handler.md) | Extract item usage logic |
+| 08 | [refactor-08-save-serializers.md](refactor-08-save-serializers.md) | Extract domain-specific serializers |
+| 09 | [refactor-09-ascii-texture-mapper.md](refactor-09-ascii-texture-mapper.md) | Separate texture mapping from rendering |
+
+### Phase D: Major Refactoring (Higher Risk)
+| Plan | File | Description |
+|------|------|-------------|
+| 10 | [refactor-10-player-components.md](refactor-10-player-components.md) | Decompose player.gd into components |
+| 11 | [refactor-11-game-ui-coordinator.md](refactor-11-game-ui-coordinator.md) | Extract UI coordination from game.gd |
+| 12 | [refactor-12-game-event-handlers.md](refactor-12-game-event-handlers.md) | Extract event handlers from game.gd |
+| 13 | [refactor-13-game-rendering-orchestrator.md](refactor-13-game-rendering-orchestrator.md) | Extract rendering orchestration from game.gd |
+
+---
+
+## Key Files Being Refactored
+
+| File | Current Lines | Target Lines | Reduction |
+|------|--------------|--------------|-----------|
+| scenes/game.gd | 3,337 | ~1,000 | 70% |
+| systems/input_handler.gd | 2,569 | ~800 | 69% |
+| ui/debug_command_menu.gd | 2,203 | ~800 | 64% |
+| entities/player.gd | 1,970 | ~800 | 59% |
+| autoload/save_manager.gd | 1,117 | ~400 | 64% |
+| items/item.gd | 1,170 | ~600 | 49% |
+| rendering/ascii_renderer.gd | 1,182 | ~900 | 24% |
+
+---
+
+## Dependencies Between Plans
+
+```
+01 JsonHelper ─────┬──> 04 Chunk Cleanup
+                   └──> 08 Save Serializers
+
+02 UI Theme ───────────> All UI file updates in later plans
+
+03 Filter Constants ───> Independent
+
+04-09 ─────────────────> Can be done in parallel after 01-03
+
+10 Player Components ──> Should complete before 11-13
+                    └──> Depends on 08 for serialization compatibility
+
+11 UI Coordinator ─────> 12 Event Handlers ─────> 13 Rendering
+```
+
+---
+
+## Verification Protocol
+
+Each plan execution should:
+
+1. **Before Starting**
+   - Ensure on correct branch
+   - Run game to verify baseline functionality
+   - Run `gut` tests if available
+
+2. **After Completing**
+   - [ ] Game launches without errors
+   - [ ] Feature-specific tests pass (listed in each plan)
+   - [ ] Save/load cycle works
+   - [ ] No new console warnings/errors
+
+3. **Rollback if Needed**
+   - Each plan should be one git commit
+   - `git revert HEAD` to undo if issues found
+
+---
+
+## Branch Strategy
+
+- Main branch: `refactor/v1.7-code-organization`
+- Each plan can optionally have sub-branch: `refactor/v1.7-plan-XX`
+- Merge to main branch after each plan is verified


### PR DESCRIPTION
Add 14 plan documents for refactoring large files into discrete modules, eliminating duplicate code, and applying DRY/SOLID principles.

Plans organized in 4 phases from lowest to highest risk:
- Phase A (Zero Risk): JsonHelper extension, UI theme constants, filter constants
- Phase B (Low Risk): Chunk cleanup mixin, input mode handlers, debug executor
- Phase C (Medium Risk): Item usage handler, save serializers, ASCII mapper
- Phase D (Higher Risk): Player components, game.gd decomposition (3 plans)

Key improvements targeted:
- game.gd: 3,337 -> ~1,000 lines (70% reduction)
- input_handler.gd: 2,569 -> ~800 lines (69% reduction)
- player.gd: 1,970 -> ~800 lines (59% reduction)
- Eliminate ~500 lines of duplicate code across managers

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>