### PR TITLE
Fix combat freeze in sewers caused by line-of-sight checks

### DIFF
--- a/systems/ranged_combat_system.gd
+++ b/systems/ranged_combat_system.gd
@@ -344,6 +344,13 @@ static func is_tile_transparent(pos: Vector2i) -> bool:
 		tile = MapManager.current_map.get_tile(pos)
 
 	if not tile:
+		# CRITICAL FIX: During turn processing, ChunkManager is frozen and may return null
+		# for tiles in unloaded chunks. For dungeons (chunk-based maps), treat null tiles
+		# as transparent during frozen state to prevent AI from freezing when checking LOS.
+		# This is safe because dungeon rooms are fully generated - missing tiles are due to
+		# freeze state, not actual walls.
+		if MapManager.current_map.chunk_based and ChunkManager.is_frozen():
+			return true
 		return false
 
 	return tile.transparent


### PR DESCRIPTION
Fixes #104

During enemy turn processing, ChunkManager freezes chunk operations to prevent signal cascades. Spellcaster enemies check line-of-sight before casting, which calls ChunkManager.get_tile() for tiles along the line. For dungeon maps, if a tile's chunk isn't in active_chunks, frozen ChunkManager returns null.

The bug: is_tile_transparent() treated null tiles as opaque (blocking), causing incorrect LOS failures. This made enemy AI loop indefinitely, freezing the game.

Fix: When chunks are frozen and tile is null in chunk-based maps, treat as transparent (safe default for dungeons since rooms are fully generated).

Generated with [Claude Code](https://claude.ai/code)