### PR TITLE
Fix: Dead entities blocking movement (issue #103)

### DIFF
--- a/entities/player.gd
+++ b/entities/player.gd
@@ -372,7 +372,7 @@ func _notify_blocked_by_tile(pos: Vector2i) -> void:
 	# (e.g., entities in map.entities but not EntityManager.entities, or edge cases)
 	if MapManager.current_map:
 		for entity in MapManager.current_map.entities:
-			if entity.position == pos and entity.blocks_movement:
+			if entity.position == pos and entity.blocks_movement and entity.is_alive:
 				EventBus.message_logged.emit("Your path is blocked by %s." % entity.name.to_lower())
 				return
 


### PR DESCRIPTION
Fixed a bug where defeated enemies were still blocking player movement. The _notify_blocked_by_tile() function in player.gd was checking entity.blocks_movement but not entity.is_alive, causing dead entities that hadn't been removed from the entities array yet to still be reported as blocking.

Added is_alive check to match the pattern used in EntityManager.get_blocking_entity_at().

Closes #103